### PR TITLE
Check if exceptions array exists

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -149,7 +149,7 @@ interface Http {
 
 interface Cause {
   working_directory: string;
-  exceptions: Array<{ message: string; type: string; stack: Array<{ path: string; line: number; label: string }> }>;
+  exceptions?: Array<{ message: string; type: string; stack: Array<{ path: string; line: number; label: string }> }>;
 }
 
 export type XrayTraceDataSegmentDocument = {

--- a/src/utils/transform.ts
+++ b/src/utils/transform.ts
@@ -97,7 +97,7 @@ function getIconColor(segment: XrayTraceDataSegmentDocument) {
 }
 
 function getStackTrace(segment: XrayTraceDataSegmentDocument) {
-  if (!segment.cause) {
+  if (!segment.cause?.exceptions) {
     return undefined;
   }
   const stackTraces: string[] = [];


### PR DESCRIPTION
Fixed error:
> Not all trace-ids show the trace time line when I click on them. Error message - Cannot read property 'forEach' of undefined. I think I read one of the emails this was already fixed ? Attached a screenshot of the error for reference (Error.png).

Seems like the exceptions can be undefined.