### PR TITLE
Add full publish workflow to CI config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,6 +4,9 @@ parameters:
   ssh-fingerprint:
     type: string
     default: ${GITHUB_SSH_FINGERPRINT}
+  codeclimate-reporter-id:
+    type: string
+    default: ${CC_TEST_REPORTER_ID}
 
 aliases:
   # Workflow filters
@@ -17,7 +20,61 @@ aliases:
 workflows:
   plugin_workflow:
     jobs:
-      - build
+      - yarn_install
+      - build_docs:
+          requires:
+            - yarn_install
+      - build_frontend:
+          requires:
+            - yarn_install
+      - code_coverage_frontend:
+          requires:
+            - build_frontend
+      - build_backend
+      - code_coverage_backend:
+          requires:
+            - build_backend
+      - upload_coverage:
+          requires:
+            - code_coverage_frontend
+            - code_coverage_backend
+      - package:
+          requires:
+            - build_frontend
+            - build_backend
+            - build_docs
+      - publish_artifacts_to_gcs:
+          requires:
+            - package
+      - test_integration:
+          requires:
+            - package
+      - report:
+          requires:
+            - test_integration
+      - approve_release:
+          type: approval
+          requires:
+            - report
+          filters: *filter-only-release
+      - publish_github_release:
+          requires:
+            - approve_release
+          filters: *filter-only-release
+      - publish_gcs_release:
+          requires:
+            - approve_release
+          filters: *filter-only-release
+      - approve_publish_to_gcom:
+          type: approval
+          requires:
+            - publish_github_release
+            - publish_gcs_release
+          filters: *filter-only-release
+      - publish_to_gcom:
+          requires:
+            - approve_publish_to_gcom
+          filters: *filter-only-release
 
 executors:
   default_exec: # declares a reusable executor
@@ -26,16 +83,25 @@ executors:
   e2e_exec:
     docker:
       - image: srclosson/grafana-plugin-ci-e2e:latest
+  python_exec:
+    docker:
+      - image: circleci/python:stretch
+  cloud_sdk_exec:
+    docker:
+      - image: google/cloud-sdk
+  grafana_publisher:
+    docker:
+      - image: briangann/integration-grafana-publisher:latest
 
 jobs:
-  build:
+  yarn_install:
     executor: default_exec
     steps:
       - checkout
       - restore_cache:
           name: restore node_modules
           keys:
-          - build-cache-{{ .Environment.CACHE_VERSION }}-{{ checksum "yarn.lock" }}
+            - build-cache-{{ .Environment.CACHE_VERSION }}-{{ checksum "yarn.lock" }}
       - run:
           name: Install dependencies
           command: |
@@ -46,9 +112,56 @@ jobs:
           paths:
             - ~/project/node_modules
           key: build-cache-{{ .Environment.CACHE_VERSION }}-{{ checksum "yarn.lock" }}
+      - save_cache:
+          name: save cypress cache
+          paths:
+            - ~/.cache/Cypress
+          key: cypress-cache-{{ .Environment.CACHE_VERSION }}-{{ checksum "yarn.lock" }}
+
+  build_docs:
+    executor: default_exec
+    steps:
+      - checkout
+      - restore_cache:
+          name: restore node_modules
+          keys:
+            - build-cache-{{ .Environment.CACHE_VERSION }}-{{ checksum "yarn.lock" }}
+      - run:
+          name: Build docs
+          command: |
+            ./node_modules/.bin/grafana-toolkit plugin:ci-docs
+            [ -d "dist" ] || circleci-agent step halt
+      - persist_to_workspace:
+          root: .
+          paths:
+            - dist
+
+  build_frontend:
+    executor: default_exec
+    steps:
+      - checkout
+      - restore_cache:
+          name: restore node_modules
+          keys:
+            - build-cache-{{ .Environment.CACHE_VERSION }}-{{ checksum "yarn.lock" }}
       - run:
           name: Build and test frontend
-          command: ./node_modules/.bin/grafana-toolkit plugin:ci-build
+          command: |
+            ./node_modules/.bin/grafana-toolkit plugin:ci-build
+            ./node_modules/.bin/grafana-toolkit plugin:ci-build --finish
+      - persist_to_workspace:
+          root: .
+          paths:
+            - ci
+
+  build_backend:
+    executor: e2e_exec
+    steps:
+      - checkout
+      - restore_cache:
+          name: restore node_modules
+          keys:
+            - build-cache-{{ .Environment.CACHE_VERSION }}-{{ checksum "yarn.lock" }}
       - run:
           name: Build backend
           command: mage -v buildAll
@@ -59,17 +172,445 @@ jobs:
             mage -v coverage
       - run:
           name: Move results to ci folder
-          command: ./node_modules/.bin/grafana-toolkit plugin:ci-build --finish
-      - run:
-          name: Package distribution
           command: |
-            ./node_modules/.bin/grafana-toolkit plugin:ci-package
+            ./node_modules/.bin/grafana-toolkit plugin:ci-build --finish
       - persist_to_workspace:
           root: .
           paths:
-          - ci/jobs/package
-          - ci/packages
-          - ci/dist
-          - ci/grafana-test-env
+            - ci/jobs/build_backend
+
+  code_coverage_frontend:
+    executor: default_exec
+    steps:
+      - checkout
+      - attach_workspace:
+          at: .
+      - restore_cache:
+          name: restore node_modules
+          keys:
+            - build-cache-{{ .Environment.CACHE_VERSION }}-{{ checksum "yarn.lock" }}
+      - run:
+          name: Run coverage report
+          command: |
+            /usr/local/bin/cc-test-reporter format-coverage -t lcov -o out/codeclimate.frontend.json ci/jobs/build_frontend/coverage/lcov.info
+      - run:
+          name: Install jest and jest-junit
+          command: yarn global add jest jest-junit
+      - run:
+          name: Run tests with JUnit as reporter
+          command: jest --ci --runInBand --reporters=default --reporters=jest-junit
+          environment:
+            JEST_JUNIT_OUTPUT_DIR: "test-results/jest/results.xml"
+      - persist_to_workspace:
+          root: .
+          paths:
+            - out
+            - ci/jobs/code_coverage_frontend
+      - store_test_results:
+          path: test-results
+
+  code_coverage_backend:
+    executor: e2e_exec
+    working_directory: /go/src/github.com/grafana/azure-data-explorer-datasource
+    steps:
+      - checkout
+      - attach_workspace:
+          at: .
+      - run:
+          name: Build backend
+          command: mage -v buildAll
+      - run:
+          name: Run coverage report
+          command: |
+            export GOPATH=/go
+            mage -v coverage
+            /usr/local/bin/cc-test-reporter format-coverage -t gocov -o out/codeclimate.backend.json coverage/backend.out
+      - persist_to_workspace:
+          root: .
+          paths:
+            - out
+            - ci/jobs/code_coverage_backend
       - store_artifacts:
-          path: ci
+          path: out
+      - store_artifacts:
+          path: ci/jobs/code_coverage_backend
+      - store_test_results:
+          path: out
+
+  upload_coverage:
+    executor: default_exec
+    #  environment:
+    #    CC_TEST_REPORTER_ID: add_this_to_circleci_config
+    steps:
+      - attach_workspace:
+          at: .
+      - run:
+          name: Upload coverage results to Code Climate
+          command: |
+            /usr/local/bin/cc-test-reporter sum-coverage out/codeclimate.*.json -d -p 2 -o out/codeclimate.total.json
+            /usr/local/bin/cc-test-reporter upload-coverage -i out/codeclimate.total.json
+
+  package:
+    executor: e2e_exec
+    steps:
+      - checkout
+      - attach_workspace:
+          at: .
+      - restore_cache:
+          name: restore node_modules
+          keys:
+            - build-cache-{{ .Environment.CACHE_VERSION }}-{{ checksum "yarn.lock" }}
+      - run:
+          name: Package Distribution (for signing/etc)
+          command: |
+            EXEC_PREFIX=gpx_adx
+            #
+            # ci-package will create the zip file
+            #
+            # move darwin/windows binaries aside
+            #
+            ls -l ci/jobs/build_backend/dist
+            mv ci/jobs/build_backend/dist/${EXEC_PREFIX}_darwin_amd64 .
+            mv ci/jobs/build_backend/dist/${EXEC_PREFIX}_windows_amd64.exe .
+            #
+            ./node_modules/.bin/grafana-toolkit plugin:ci-package
+            #
+            #
+            PLUGIN_NAME=`cat ci/dist/plugin.json|jq '.id'| sed s/\"//g`
+            VERSION=`cat ci/dist/plugin.json|jq '.info.version'| sed s/\"//g`
+            echo "Plugin Name: ${PLUGIN_NAME}"
+            echo "Plugin Version: ${VERSION}"
+            #
+            # Building separate linux and windows zip files
+            #
+            # 1. rename to linux package
+            #
+            mv ci/packages/${PLUGIN_NAME}-${VERSION}.zip \
+              ci/packages/${PLUGIN_NAME}-${VERSION}.linux_amd64.zip
+            mv ci/packages/${PLUGIN_NAME}-${VERSION}.zip.sha1 \
+              ci/packages/${PLUGIN_NAME}-${VERSION}.linux_amd64.zip.sha1
+            #
+            # 2. update info.json with new zip file name
+            #
+            sed -i 's/zip/linux_amd64\.zip/g' ci/packages/info.json
+            #
+            # 3. move into linux subdir
+            #
+            mkdir -p temp_ci/packages/linux
+            cp -p ci/packages/info.json temp_ci/packages/linux
+            cp -p ci/packages/info.json temp_ci/packages/linux/info-linux.json
+            mv ci/packages/${PLUGIN_NAME}* temp_ci/packages/linux
+            #
+            # now create the windows package
+            #
+            # 4. re-run ci-package to create the windows-only zip
+            #
+            ls -l ci/jobs/build_backend/dist
+            mv ci/jobs/build_backend/dist/${EXEC_PREFIX}_linux_amd64 .
+            ls -l ${EXEC_PREFIX}*
+            mv ${EXEC_PREFIX}_windows_amd64.exe ci/jobs/build_backend/dist
+            ls -l ci/jobs/build_backend/dist
+            ./node_modules/.bin/grafana-toolkit plugin:ci-package
+            #
+            # 5. rename zip
+            #
+            mv ci/packages/${PLUGIN_NAME}-${VERSION}.zip \
+              ci/packages/${PLUGIN_NAME}-${VERSION}.windows_amd64.zip
+            mv ci/packages/${PLUGIN_NAME}-${VERSION}.zip.sha1 \
+              ci/packages/${PLUGIN_NAME}-${VERSION}.windows_amd64.zip.sha1
+            #
+            # update info.json with new zip file name
+            #
+            sed -i 's/zip/windows_amd64\.zip/g' ci/packages/info.json
+            #
+            # 6. move into windows subdir
+            #
+            mkdir temp_ci/packages/windows
+            # report needs info.json, so keep a copy here
+            cp ci/packages/info.json temp_ci/packages/windows
+            cp ci/packages/info.json temp_ci/packages/windows/info-windows.json
+            mv ci/packages/${PLUGIN_NAME}* temp_ci/packages/windows
+            #
+            # now create the darwin package
+            #
+            # 7. re-run ci-package to create the darwin-only zip
+            #
+            ls -l ci/jobs/build_backend/dist
+            mv ci/jobs/build_backend/dist/${EXEC_PREFIX}_windows_amd64.exe .
+            mv ${EXEC_PREFIX}_darwin_amd64 ci/jobs/build_backend/dist
+            ls -l ci/jobs/build_backend/dist
+            ./node_modules/.bin/grafana-toolkit plugin:ci-package
+            #
+            # 8. rename zip
+            #
+            mv ci/packages/${PLUGIN_NAME}-${VERSION}.zip \
+              ci/packages/${PLUGIN_NAME}-${VERSION}.darwin_amd64.zip
+            mv ci/packages/${PLUGIN_NAME}-${VERSION}.zip.sha1 \
+              ci/packages/${PLUGIN_NAME}-${VERSION}.darwin_amd64.zip.sha1
+            #
+            # update info.json with new zip file name
+            #
+            sed -i 's/zip/darwin_amd64\.zip/g' ci/packages/info.json
+            #
+            # 9. move into windows subdir
+            #
+            mkdir ci/packages/darwin
+            # report needs info.json, so keep a copy here
+            cp ci/packages/info.json ci/packages/darwin
+            cp ci/packages/info.json ci/packages/darwin/info-darwin.json
+            mv ci/packages/${PLUGIN_NAME}* ci/packages/darwin
+            #
+            # 10. put the builds back into place
+            #
+            mv temp_ci/packages/linux ci/packages
+            mv temp_ci/packages/windows ci/packages
+            # DONE
+            echo Packages
+            ls -lR ci/packages
+            # put the executables back for GHR to use
+            echo Contents of ci/jobs/build_backend/dist
+            ls -lR ci/jobs/build_backend/dist
+            ls -l ${EXEC_PREFIX}*
+            mv ${EXEC_PREFIX}_linux_amd64 ci/jobs/build_backend/dist
+            mv ${EXEC_PREFIX}_windows_amd64.exe ci/jobs/build_backend/dist
+            ls -l ci/jobs/build_backend/dist
+            cp -p ci/jobs/build_backend/dist/${EXEC_PREFIX}* ci/dist/${PLUGIN_NAME}/
+            echo final dist for GHR
+            ls -lR ci/dist
+      - persist_to_workspace:
+          root: .
+          paths:
+            - ci/dist
+            - ci/jobs/package
+            - ci/jobs/build_backend/dist
+            - ci/grafana-test-env
+            - ci/packages
+      - store_artifacts:
+          path: ci/packages
+
+  test_integration:
+    executor: default_exec
+    steps:
+      - checkout
+      - attach_workspace:
+          at: .
+      - restore_cache:
+          keys:
+            - build-cache-{{ .Environment.CACHE_VERSION }}-{{ checksum "yarn.lock" }}
+      - run:
+          name: Setup Grafana (local install)
+          command: |
+            ginstall latest
+            /opt/grafana/bin/grafana-server -config ci/grafana-test-env/custom.ini -homepath /opt/grafana &
+            /opt/grafana/bin/grafana-cli --version
+      - run:
+          name: Install dependencies
+          command: yarn install --frozen-lockfile
+      - save_cache:
+          paths:
+            - ~/.cache
+          key: yarn-packages-{{ .Environment.CACHE_VERSION }}-{{ checksum "yarn.lock" }}
+      - run:
+          name: Run e2e tests
+          command: echo TODO npx grafana-e2e run
+      - run:
+          name: Prepare task output dir
+          command: |
+            [ -d cypress ] && npx grafana-e2e run || echo "skipping e2e"
+      - run:
+          name: Prepare task output dir
+          command: |
+            # TODO: probably move all of this to `@grafana/toolkit plugin:ci-test`
+            mkdir -m 0755 -p ci/jobs/test_integration
+            # only copy if they exist
+            if [ -d cypress ]; then
+              [ -d cypress/screenshots ] && cp cypress/screenshots/ ci/jobs/test_integration || echo "ignoring screenshots dir."
+              [ -d cypress/videos ] && cp cypress/videos/ ci/jobs/test_integration || echo "ignoring videos dir."
+            else
+              # Not handling the else will return -1, so run something so that we get a 0 exit code
+              echo "No cypress directory. Ignoring."
+            fi
+      - persist_to_workspace:
+          root: .
+          paths:
+            - ci/jobs/test_integration
+      - store_test_results:
+          path: ci/jobs/test_integration
+      - store_artifacts:
+          path: ci/jobs/test_integration
+
+  report:
+    executor: default_exec
+    steps:
+      - checkout
+      - attach_workspace:
+          at: .
+      - restore_cache:
+          name: restore node_modules
+          keys:
+            - build-cache-{{ .Environment.CACHE_VERSION }}-{{ checksum "yarn.lock" }}
+      - run:
+          name: Toolkit report
+          command: |
+            ./node_modules/.bin/grafana-toolkit plugin:ci-report
+
+  publish_gcs_release:
+    executor: cloud_sdk_exec
+    steps:
+      - checkout
+      - attach_workspace:
+          at: .
+      - run:
+          name: "Copy Artifacts to GCP Release Bucket"
+          command: |
+            ls -l ci/jobs/build_frontend/dist/plugin.json
+            echo "Contents of ci/jobs/build_frontend/dist/plugin.json"
+            cat ci/jobs/build_frontend/dist/plugin.json
+            ls -lR ci/packages
+            apt update
+            apt install -y jq git-lfs
+            PLUGIN_NAME=`cat ci/dist/plugin.json|jq '.id'| sed s/\"//g`
+            echo "Plugin Name: ${PLUGIN_NAME}"
+            VERSION=`cat ci/dist/plugin.json|jq '.info.version'| sed s/\"//g`
+            echo "Plugin Version: ${VERSION}"
+            # copy
+            if [ -z "${GCLOUD_SERVICE_KEY}" ]; then
+              echo "Missing GCS Publish Key"
+              exit -1
+            fi
+            echo ${GCLOUD_SERVICE_KEY} | gcloud auth activate-service-account --key-file=-
+            echo "Contents of artifacts"
+            echo "Copying artifacts to ${PLUGIN_NAME}/${VERSION}/${CIRCLE_BRANCH}/${CIRCLE_SHA1}"
+            if [ -d ci/packages/linux ]; then
+              gsutil -m cp -r ci/packages/linux/** gs://integration-artifacts/${PLUGIN_NAME}/release/${VERSION}/linux
+            fi
+            if [ -d ci/packages/windows ]; then
+              gsutil -m cp -r ci/packages/windows/** gs://integration-artifacts/${PLUGIN_NAME}/release/${VERSION}/windows
+            fi
+            if [ -d ci/packages/darwin ]; then
+              gsutil -m cp -r ci/packages/darwin/** gs://integration-artifacts/${PLUGIN_NAME}/release/${VERSION}/darwin
+            fi
+            if [ -d ci/packages/any ]; then
+              gsutil -m cp -r ci/packages/any/** gs://integration-artifacts/${PLUGIN_NAME}/release/${VERSION}/any
+            fi
+
+  publish_github_release:
+    working_directory: ~/azure-data-explorer-datasource
+    docker:
+      - image: cibuilds/github:0.13.0
+    steps:
+      - checkout
+      - add_ssh_keys:
+          fingerprints:
+            - << pipeline.parameters.ssh-fingerprint >>
+      - attach_workspace:
+          at: .
+      - restore_cache:
+          name: restore node_modules
+          keys:
+            - build-cache-{{ .Environment.CACHE_VERSION }}-{{ checksum "yarn.lock" }}
+      - run:
+          name: "Publish Release on GitHub"
+          command: |
+            # copy ci artifacts
+            mkdir -p artifacts
+            cp ci/packages/linux/* artifacts
+            cp ci/packages/windows/* artifacts
+            if [ -d ci/packages/darwin ]; then
+              cp ci/packages/darwin/* artifacts
+            fi
+            apk add --update --no-cache jq git-lfs
+            PLUGIN_NAME=`cat ci/dist/plugin.json|jq '.id'| sed s/\"//g`
+            echo "Plugin Name: ${PLUGIN_NAME}"
+            VERSION=`cat ci/dist/plugin.json|jq '.info.version'| sed s/\"//g`
+            echo "Plugin Version: ${VERSION}"
+            RELEASE_NOTES=`awk 'BEGIN {FS="##"; RS=""} FNR==4 {print; exit}' CHANGELOG.md`
+            git config user.email "eng@grafana.com"
+            git config user.name "CircleCI Automation"
+            git checkout -b release-${VERSION}
+            # add dist, it is needed to get the right plugin.json info during gcom publish
+            mkdir -p dist
+            cp -rp ci/dist/${PLUGIN_NAME}/* dist/
+            git add --force dist/
+            git commit -m "automated release $VERSION [skip ci]"
+            git push -f origin release-${VERSION}
+            git tag -f v${VERSION}
+            git push -f origin v${VERSION}
+            ghr \
+              -t ${GITHUB_TOKEN} \
+              -u ${CIRCLE_PROJECT_USERNAME} \
+              -r ${CIRCLE_PROJECT_REPONAME} \
+              -c ${CIRCLE_SHA1} \
+              -n "${PLUGIN_NAME} v${VERSION}" \
+              -b "${RELEASE_NOTES}" \
+              -delete \
+              v${VERSION} \
+              ./artifacts/
+
+  publish_artifacts_to_gcs:
+    executor: cloud_sdk_exec
+    steps:
+      - checkout
+      - attach_workspace:
+          at: .
+      - run:
+          name: "Copy Artifacts to GCP Bucket"
+          command: |
+            ls -l ci/jobs/build_frontend/dist/plugin.json
+            echo "Contents of ci/jobs/build_frontend/dist/plugin.json"
+            cat ci/jobs/build_frontend/dist/plugin.json
+            ls -lR ci/packages
+            apt update
+            apt install -y jq git-lfs
+            PLUGIN_NAME=`cat ci/dist/plugin.json|jq '.id'| sed s/\"//g`
+            echo "Plugin Name: ${PLUGIN_NAME}"
+            VERSION=`cat ci/dist/plugin.json|jq '.info.version'| sed s/\"//g`
+            echo "Plugin Version: ${VERSION}"
+            # copy
+            if [ -z "${GCLOUD_SERVICE_KEY}" ]; then
+              echo "Missing GCS Publish Key"
+              exit -1
+            fi
+            echo ${GCLOUD_SERVICE_KEY} | gcloud auth activate-service-account --key-file=-
+            echo "Contents of artifacts"
+            echo "Copying artifacts to ${PLUGIN_NAME}/${VERSION}/${CIRCLE_BRANCH}/${CIRCLE_SHA1}"
+            gsutil -m cp -r ci/packages/** gs://integration-artifacts/${PLUGIN_NAME}/${VERSION}/${CIRCLE_BRANCH}/${CIRCLE_SHA1}
+            echo "Cleaning latest"
+            gsutil rm -f gs://integration-artifacts/${PLUGIN_NAME}/${VERSION}/${CIRCLE_BRANCH}/latest/** || true
+            echo "Copying artifacts to ${PLUGIN_NAME}/${VERSION}/${CIRCLE_BRANCH}/latest"
+            gsutil -m cp -r ci/packages/** gs://integration-artifacts/${PLUGIN_NAME}/${VERSION}/${CIRCLE_BRANCH}/latest
+            # special handling for master
+            if [ ${CIRCLE_BRANCH} == "master" ]; then
+              echo "Cleaning master latest"
+              gsutil rm -f gs://integration-artifacts/${PLUGIN_NAME}/${CIRCLE_BRANCH}/latest/** || true
+              echo "Copying artifacts to master latest"
+              gsutil -m cp -r ci/packages/** gs://integration-artifacts/${PLUGIN_NAME}/${CIRCLE_BRANCH}/latest
+            fi
+            gsutil ls -r gs://integration-artifacts/${PLUGIN_NAME}
+
+  publish_to_gcom:
+    executor: grafana_publisher
+    steps:
+      - checkout
+      - attach_workspace:
+          at: .
+      - run:
+          name: "Publish to GCOM"
+          command: |
+            if [ -z "${GCOM_PUBLISH_TOKEN}" ]; then
+              echo "Missing GCOM Publish Key"
+              exit -1
+            fi
+            if [ -z "${GITHUB_TOKEN}" ]; then
+              echo "Missing GITHUB_TOKEN"
+              exit -1
+            fi
+            if [ -z "${GCLOUD_SERVICE_KEY}" ]; then
+              echo "Missing GCLOUD_SERVICE_KEY"
+              exit -1
+            fi
+            PLUGIN_NAME=`cat ci/dist/plugin.json|jq '.id'| sed s/\"//g`
+            PLUGIN_VERSION=`cat ci/dist/plugin.json|jq '.info.version'| sed s/\"//g`
+            echo ${GCLOUD_SERVICE_KEY} | gcloud auth activate-service-account --key-file=-
+            echo "Publishing to GCOM: $PLUGIN_NAME $PLUGIN_VERSION"
+            /root/app/bin/grafana-publisher.js --auto publishremote $PLUGIN_NAME $PLUGIN_VERSION

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -263,7 +263,7 @@ jobs:
       - run:
           name: Package Distribution (for signing/etc)
           command: |
-            EXEC_PREFIX=gpx_adx
+            EXEC_PREFIX=gpx_x-ray-datasource
             #
             # ci-package will create the zip file
             #

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -211,7 +211,7 @@ jobs:
 
   code_coverage_backend:
     executor: e2e_exec
-    working_directory: /go/src/github.com/grafana/azure-data-explorer-datasource
+    working_directory: /go/src/github.com/grafana/x-ray-datasource
     steps:
       - checkout
       - attach_workspace:
@@ -495,7 +495,7 @@ jobs:
             fi
 
   publish_github_release:
-    working_directory: ~/azure-data-explorer-datasource
+    working_directory: ~/x-ray-datasource
     docker:
       - image: cibuilds/github:0.13.0
     steps:


### PR DESCRIPTION
Adds full workflow that tests, builds, signs and publishes the plugin. Taken from https://github.com/grafana/azure-data-explorer-datasource.