### PR TITLE
Implement static and dynamic sampling

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,4 +8,5 @@ require (
 	github.com/bmizerany/assert v0.0.0-20160611221934-b7ed37b82869 // indirect
 	github.com/grafana/grafana-plugin-sdk-go v0.65.0
 	github.com/stretchr/testify v1.5.1
+	golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e
 )

--- a/go.sum
+++ b/go.sum
@@ -156,6 +156,7 @@ golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sync v0.0.0-20181108010431-42b317875d0f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20181221193216-37e7f081c4d4/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e h1:vcxGaoTs7kV8m5Np9uUNQin4BrLOthgV7252N8V+FwY=
 golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20180830151530-49385e6e1522/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180905080454-ebe1bf3edb33/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=

--- a/pkg/datasource/datasource.go
+++ b/pkg/datasource/datasource.go
@@ -128,5 +128,4 @@ type XrayClient interface {
 	) error
 	GetInsightSummaries(input *xray.GetInsightSummariesInput) (*xray.GetInsightSummariesOutput, error)
 	GetGroupsPages(input *xray.GetGroupsInput, fn func(*xray.GetGroupsOutput, bool) bool ) error
-  GetServiceGraphPagesWithContext(ctx aws.Context, input *xray.GetServiceGraphInput, fn func(*xray.GetServiceGraphOutput, bool) bool, opts ...request.Option) error
 }

--- a/pkg/datasource/datasource.go
+++ b/pkg/datasource/datasource.go
@@ -118,6 +118,7 @@ func getXrayClient(pluginContext *backend.PluginContext) (XrayClient, error) {
 
 type XrayClient interface {
 	BatchGetTraces(input *xray.BatchGetTracesInput) (*xray.BatchGetTracesOutput, error)
+  GetTraceSummariesWithContext(ctx aws.Context, input *xray.GetTraceSummariesInput, opts ...request.Option) (*xray.GetTraceSummariesOutput, error)
 	GetTraceSummariesPages(input *xray.GetTraceSummariesInput, fn func(*xray.GetTraceSummariesOutput, bool) bool) error
 	GetTimeSeriesServiceStatisticsPagesWithContext(
 		aws.Context,
@@ -127,4 +128,5 @@ type XrayClient interface {
 	) error
 	GetInsightSummaries(input *xray.GetInsightSummariesInput) (*xray.GetInsightSummariesOutput, error)
 	GetGroupsPages(input *xray.GetGroupsInput, fn func(*xray.GetGroupsOutput, bool) bool ) error
+  GetServiceGraphPagesWithContext(ctx aws.Context, input *xray.GetServiceGraphInput, fn func(*xray.GetServiceGraphOutput, bool) bool, opts ...request.Option) error
 }

--- a/pkg/datasource/datasource_test.go
+++ b/pkg/datasource/datasource_test.go
@@ -112,21 +112,26 @@ func makeSummary() *xray.TraceSummary {
 }
 
 func (client *XrayClientMock) GetTraceSummariesPages(input *xray.GetTraceSummariesInput, fn func(*xray.GetTraceSummariesOutput, bool) bool) error {
+  resp, err := client.GetTraceSummariesWithContext(context.Background(), input)
+	fn(resp, true)
+	return err
+}
 
-	// To make sure we don't panic in this case.
-	nilHttpSummary := makeSummary()
-	nilHttpSummary.Http.ClientIp = nil
-	nilHttpSummary.Http.HttpURL = nil
-	nilHttpSummary.Http.HttpMethod = nil
-	nilHttpSummary.Http.HttpStatus = nil
 
-	output := &xray.GetTraceSummariesOutput{
-		ApproximateTime: aws.Time(time.Now()),
-		TraceSummaries:  []*xray.TraceSummary{makeSummary(), nilHttpSummary},
-	}
-	fn(output, true)
+func (client *XrayClientMock) GetTraceSummariesWithContext(ctx aws.Context, input *xray.GetTraceSummariesInput, opts ...request.Option) (*xray.GetTraceSummariesOutput, error) {
+  // To make sure we don't panic in this case.
+  nilHttpSummary := makeSummary()
+  nilHttpSummary.Http.ClientIp = nil
+  nilHttpSummary.Http.HttpURL = nil
+  nilHttpSummary.Http.HttpMethod = nil
+  nilHttpSummary.Http.HttpStatus = nil
 
-	return nil
+  output := &xray.GetTraceSummariesOutput{
+    ApproximateTime: aws.Time(time.Now()),
+    TraceSummaries:  []*xray.TraceSummary{makeSummary(), nilHttpSummary},
+  }
+
+  return output, nil
 }
 
 func (client *XrayClientMock) BatchGetTraces(input *xray.BatchGetTracesInput) (*xray.BatchGetTracesOutput, error) {
@@ -449,19 +454,19 @@ func TestDatasource(t *testing.T) {
 
 	t.Run("getAnalyticsRootCauseErrorService query", func(t *testing.T) {
 		testAnalytics(t, ds, datasource.QueryGetAnalyticsRootCauseErrorService, [][]interface{}{
-			{"service_name_1 (service_type_1)", int64(2), float64(100)},
+			{"service_name_1 (service_type_1)", int64(8), float64(100)},
 		})
 	})
 
 	t.Run("getAnalyticsRootCauseErrorPath query", func(t *testing.T) {
 		testAnalytics(t, ds, datasource.QueryGetAnalyticsRootCauseErrorPath, [][]interface{}{
-			{"service_name_1 (service_type_1) -> Test exception", int64(2), float64(100)},
+			{"service_name_1 (service_type_1) -> Test exception", int64(8), float64(100)},
 		})
 	})
 
 	t.Run("getAnalyticsRootCauseErrorMessage query", func(t *testing.T) {
 		testAnalytics(t, ds, datasource.QueryGetAnalyticsRootCauseErrorMessage, [][]interface{}{
-			{"Test exception message", int64(2), float64(100)},
+			{"Test exception message", int64(8), float64(100)},
 		})
 	})
 
@@ -471,19 +476,19 @@ func TestDatasource(t *testing.T) {
 
 	t.Run("getAnalyticsRootCauseFaultService query", func(t *testing.T) {
 		testAnalytics(t, ds, datasource.QueryGetAnalyticsRootCauseFaultService, [][]interface{}{
-			{"faulty_service_name_1 (faulty_service_type_1)", int64(2), float64(100)},
+			{"faulty_service_name_1 (faulty_service_type_1)", int64(8), float64(100)},
 		})
 	})
 
 	t.Run("getAnalyticsRootCauseFaultPath query", func(t *testing.T) {
 		testAnalytics(t, ds, datasource.QueryGetAnalyticsRootCauseFaultPath, [][]interface{}{
-			{"faulty_service_name_1 (faulty_service_type_1) -> Test fault", int64(2), float64(100)},
+			{"faulty_service_name_1 (faulty_service_type_1) -> Test fault", int64(8), float64(100)},
 		})
 	})
 
 	t.Run("getAnalyticsRootCauseFaultMessage query", func(t *testing.T) {
 		testAnalytics(t, ds, datasource.QueryGetAnalyticsRootCauseFaultMessage, [][]interface{}{
-			{"Test fault message", int64(2), float64(100)},
+			{"Test fault message", int64(8), float64(100)},
 		})
 	})
 
@@ -493,7 +498,7 @@ func TestDatasource(t *testing.T) {
 
 	t.Run("getAnalyticsRootCauseResponseTimeService query", func(t *testing.T) {
 		testAnalytics(t, ds, datasource.QueryGetAnalyticsRootCauseResponseTimeService, [][]interface{}{
-			{"response_service_name_2 (response_service_type_2)", int64(2), float64(100)},
+			{"response_service_name_2 (response_service_type_2)", int64(8), float64(100)},
 		})
 	})
 
@@ -501,7 +506,7 @@ func TestDatasource(t *testing.T) {
 		testAnalytics(t, ds, datasource.QueryGetAnalyticsRootCauseResponseTimePath, [][]interface{}{
 			{
 				"response_service_name_1 (response_service_type_1) -> response_sub_service_name_1 => response_service_name_2 (response_service_type_2) -> response_sub_service_name_2",
-				int64(2),
+				int64(8),
 				float64(100),
 			},
 		})

--- a/pkg/datasource/getAnalytics.go
+++ b/pkg/datasource/getAnalytics.go
@@ -236,8 +236,7 @@ func getTracesCount(ctx context.Context, xrayClient XrayClient, from time.Time, 
     return true
   })
 
-  return count, err
-
+  return count / 2, err
 }
 
 type DataProcessor struct {

--- a/pkg/datasource/getAnalytics.go
+++ b/pkg/datasource/getAnalytics.go
@@ -9,10 +9,10 @@ import (
   "github.com/grafana/grafana-plugin-sdk-go/backend/log"
   "github.com/grafana/grafana-plugin-sdk-go/data"
   "github.com/grafana/x-ray-datasource/pkg/xray"
+  "golang.org/x/sync/errgroup"
   "math"
   "math/rand"
   "strconv"
-  "sync"
   "time"
 )
 
@@ -31,17 +31,19 @@ func (ds *Datasource) getAnalytics(ctx context.Context, req *backend.QueryDataRe
 		Responses: make(map[string]backend.DataResponse),
 	}
 
+	// TODO this could be parallelized
 	for _, query := range req.Queries {
-		response.Responses[query.RefID] = getSingleAnalyticsResult(ctx, xrayClient, query)
+		response.Responses[query.RefID] = getSingleAnalyticsQueryResult(ctx, xrayClient, query)
 	}
 
 	return response, nil
 }
 
-func getSingleAnalyticsResult(ctx context.Context, xrayClient XrayClient, query backend.DataQuery) backend.DataResponse {
+func getSingleAnalyticsQueryResult(ctx context.Context, xrayClient XrayClient, query backend.DataQuery) backend.DataResponse {
 	log.DefaultLogger.Debug("getSingleAnalyticsResult", "type", query.QueryType, "RefID", query.RefID)
 
-	traces, err := getTraceSummariesData(ctx, xrayClient, query)
+  const maxTraces = 10000
+	traces, err := getTraceSummariesData(ctx, xrayClient, query, maxTraces)
 
 	if err != nil {
 		log.DefaultLogger.Debug("getSingleAnalyticsResult", "error", err)
@@ -59,7 +61,7 @@ func getSingleAnalyticsResult(ctx context.Context, xrayClient XrayClient, query 
 	}
 }
 
-func getTraceSummariesData(ctx context.Context, xrayClient XrayClient, query backend.DataQuery) ([]*xray.TraceSummary, error) {
+func getTraceSummariesData(ctx context.Context, xrayClient XrayClient, query backend.DataQuery, maxTraces int) ([]*xray.TraceSummary, error) {
 	queryData := &GetAnalyticsQueryData{}
 	err := json.Unmarshal(query.JSON, queryData)
 
@@ -68,7 +70,6 @@ func getTraceSummariesData(ctx context.Context, xrayClient XrayClient, query bac
 	}
 	log.DefaultLogger.Debug("getTraceSummariesData", "query", queryData.Query)
 
-  const maxTraces = 10000
   diff := query.TimeRange.To.Sub(query.TimeRange.From)
   log.DefaultLogger.Debug("getTraceSummariesData", "diff", diff.Minutes())
   diffQuarter := diff.Nanoseconds() / 4
@@ -79,9 +80,13 @@ func getTraceSummariesData(ctx context.Context, xrayClient XrayClient, query bac
   adaptiveSampling := true
 
   if queryData.Query == "" {
+    var groupARN *string
+    if queryData.Group != nil {
+      groupARN = queryData.Group.GroupARN
+    }
     // Get count of all the traces so we can compute sampling. The API used does not allow for filter expression so
     // we can do this only if we don't have one.
-    count, err := getTracesCount(ctx, xrayClient, query.TimeRange.From, query.TimeRange.To, *queryData.Group.GroupARN)
+    count, err := getTracesCount(ctx, xrayClient, query.TimeRange.From, query.TimeRange.To, groupARN)
     if err != nil {
       return nil, err
     }
@@ -106,7 +111,10 @@ func getTraceSummariesData(ctx context.Context, xrayClient XrayClient, query bac
   for hasTokens {
     log.DefaultLogger.Debug("getTraceSummariesData loop start")
     // Run the four parallel requests, returns when all are done
-    responses := runRequests(ctx, xrayClient, requests, tokens)
+    responses, err := runRequests(ctx, xrayClient, requests, tokens)
+    if err != nil {
+      return nil, err
+    }
 
     // Append traces and get tokens for next page for each request
     for i, resp := range responses {
@@ -120,13 +128,15 @@ func getTraceSummariesData(ctx context.Context, xrayClient XrayClient, query bac
       }
     }
 
-    // Check if we still have at least one next token
+    // Check if we still have at least one next token. Some requests can end paging sooner than other ones.
     hasTokens = false
     for _, t := range tokens {
+      log.DefaultLogger.Debug("getTraceSummariesData", "tokens", tokens)
       if len(t) > 0 {
         hasTokens = true
         break
       }
+      log.DefaultLogger.Debug("getTraceSummariesData no more tokens")
     }
 
     // If we have more traces and did not compute correct sampling beforehand, sample what we already have, set a new
@@ -165,10 +175,15 @@ func makeRequest(from time.Time, to time.Time, sampling float64, filterExpressio
   }
 }
 
+var seed int64
+
 // sampleTraces just filters 50% of the traces from the provided list.
 func sampleTraces(traces []*xray.TraceSummary) []*xray.TraceSummary {
   var samples []*xray.TraceSummary
   s := rand.NewSource(time.Now().UnixNano())
+  if seed != 0 {
+    s = rand.NewSource(seed)
+  }
   r := rand.New(s)
 
   for _, trace := range traces {
@@ -179,9 +194,13 @@ func sampleTraces(traces []*xray.TraceSummary) []*xray.TraceSummary {
   return samples
 }
 
-// runRequests runs 4 trace summary requests and in parallel and returns slice of responses once all are done.
-func runRequests(ctx context.Context, xrayClient XrayClient, requests []*xray.GetTraceSummariesInput, tokens []string) []*xray.GetTraceSummariesOutput {
-  var wg sync.WaitGroup
+// runRequests runs 4 trace summary requests in parallel and returns slice of responses once all are done.
+func runRequests(ctx context.Context, xrayClient XrayClient, requests []*xray.GetTraceSummariesInput, tokens []string) ([]*xray.GetTraceSummariesOutput, error) {
+  group, groupCtx := errgroup.WithContext(ctx)
+
+  // We need to keep the responses ordered the same way the requests were. Reason is we need to update the requests with
+  // NextToken for the next run and each request pages through different time range so they need to be correctly matched
+  // later on.
   responses := []*xray.GetTraceSummariesOutput{nil, nil, nil, nil}
 
   for i, request := range requests {
@@ -189,56 +208,67 @@ func runRequests(ctx context.Context, xrayClient XrayClient, requests []*xray.Ge
       if tokens[i] != "first" {
         request.NextToken = aws.String(tokens[i])
       }
-      wg.Add(1)
-      go getTraceSummaries(ctx, xrayClient, request, &wg, &responses, i)
+      // Capture these for the go routine closure
+      index := i
+      req := *request
+      group.Go(func() error {
+        resp, err := getTraceSummaries(groupCtx, xrayClient, req)
+        if err != nil {
+          return err
+        }
+        responses[index] = resp
+        return nil
+      })
     }
   }
 
-  wg.Wait()
-  return responses
+  if err := group.Wait(); err != nil {
+    return nil, err
+  }
+  return responses, nil
 }
 
-func getTraceSummaries(ctx context.Context, xrayClient XrayClient, request *xray.GetTraceSummariesInput, wg *sync.WaitGroup, responses *[]*xray.GetTraceSummariesOutput, index int) {
-  defer wg.Done()
-  resp, err := xrayClient.GetTraceSummariesWithContext(ctx, request)
+func getTraceSummaries(ctx context.Context, xrayClient XrayClient, request xray.GetTraceSummariesInput) (*xray.GetTraceSummariesOutput, error) {
+  resp, err := xrayClient.GetTraceSummariesWithContext(ctx, &request)
   if err != nil {
-    log.DefaultLogger.Error("getTraceSummaries", "err", err)
+    return nil, err
   }
-  log.DefaultLogger.Debug(
-    "getTraceSummaries",
-    "from", request.StartTime,
-    "to", request.EndTime,
-    "len(traces)", len(resp.TraceSummaries),
-    "resp.NextToken", resp.NextToken,
-    "req.NextToken", request.NextToken,
-    "req.FilterExpression", request.FilterExpression,
-  )
-  (*responses)[index] = resp
+  log.DefaultLogger.Debug( "getTraceSummaries", "from", request.StartTime, "to", request.EndTime, "len(traces)", len(resp.TraceSummaries))
+  return resp, nil
 }
 
-// getTracesCount returns count of all the traces in the time range. It uses Service Graph API for that to go through
-// counts per service which should be the most efficient way to do that right now. One caveat is that it does not allow
-// for filter expression.
-func getTracesCount(ctx context.Context, xrayClient XrayClient, from time.Time, to time.Time, groupArn string) (int64, error) {
-  input := &xray.GetServiceGraphInput{
-    StartTime:             aws.Time(from),
-    EndTime:               aws.Time(to),
-    GroupARN:              aws.String(groupArn),
-  }
-  count := int64(0)
+// getTracesCount returns count of all the traces in the time range. It uses TimeSeries API for that to go through
+// counts per service or edge which should be the most efficient way to do that right now. One caveat is that it does
+// not allow for filter expression (or it does but only in some subset of expressions).
+func getTracesCount(ctx context.Context, xrayClient XrayClient, from time.Time, to time.Time, groupArn *string) (int64, error) {
   log.DefaultLogger.Debug("getTracesCount", "from", from, "to", to, "groupARN", groupArn)
-  err := xrayClient.GetServiceGraphPagesWithContext(ctx, input, func(output *xray.GetServiceGraphOutput, b bool) bool {
-    for _, service := range output.Services {
-      if service.SummaryStatistics != nil {
-        count += *service.SummaryStatistics.TotalCount
+  input := &xray.GetTimeSeriesServiceStatisticsInput{
+    StartTime: aws.Time(from),
+    EndTime:   aws.Time(to),
+    GroupARN:  groupArn,
+    Period:    aws.Int64(60) ,
+  }
+
+  count := int64(0)
+  err := xrayClient.GetTimeSeriesServiceStatisticsPagesWithContext(ctx, input, func(output *xray.GetTimeSeriesServiceStatisticsOutput, b bool) bool {
+    for _, stats := range output.TimeSeriesServiceStatistics {
+      // Not sure if this can return ServiceSummaryStatistics. It should be returned only if a service filter expression
+      // is defined for a particular service but I would assume a Group can also trigger this.
+      if stats.ServiceSummaryStatistics != nil {
+        count += *stats.ServiceSummaryStatistics.TotalCount
+      } else if stats.EdgeSummaryStatistics != nil {
+        count += *stats.EdgeSummaryStatistics.TotalCount
       }
     }
     return true
   })
 
-  return count / 2, err
+  return count, err
 }
 
+// DataProcessor is responsible for counting and aggregating the trace data byt different columns. It is stateful mainly
+// because before it just provided a callback to process one trace at the time. After sampling was added this processes
+// the whole array of traces so could be refactored to stateless function.
 type DataProcessor struct {
 	counts    map[string]int64
 	total     int64
@@ -254,11 +284,13 @@ func NewDataProcessor(queryType string) *DataProcessor {
 
 func (dataProcessor *DataProcessor) processTraces(traces []*xray.TraceSummary) {
   for _, trace := range traces {
-    dataProcessor.processSummary(trace)
+    dataProcessor.processSingleTrace(trace)
   }
 }
 
-func (dataProcessor *DataProcessor) processSummary(summary *xray.TraceSummary) {
+// processSingleTrace mainly figures out the proper aggregation key for the trace. There is lots of duplication because
+// even though various attributes in the trace summary have the same structure they have different types.
+func (dataProcessor *DataProcessor) processSingleTrace(summary *xray.TraceSummary) {
 	switch dataProcessor.queryType {
 	case QueryGetAnalyticsRootCauseResponseTimeService, QueryGetAnalyticsRootCauseResponseTimePath:
 		if len(summary.ResponseTimeRootCauses) == 0 {
@@ -388,6 +420,7 @@ func (dataProcessor *DataProcessor) dataframe() *data.Frame {
 	return frame
 }
 
+// Labels that will be used for column name.
 var labels = map[string]string{
 	QueryGetAnalyticsRootCauseResponseTimeService: "Response Time Root Cause",
 	QueryGetAnalyticsRootCauseResponseTimePath:    "Response Time Root Cause Path",

--- a/pkg/datasource/getAnalytics.go
+++ b/pkg/datasource/getAnalytics.go
@@ -71,7 +71,6 @@ func getTraceSummariesData(ctx context.Context, xrayClient XrayClient, query bac
 	log.DefaultLogger.Debug("getTraceSummariesData", "query", queryData.Query)
 
   diff := query.TimeRange.To.Sub(query.TimeRange.From)
-  log.DefaultLogger.Debug("getTraceSummariesData", "diff", diff.Minutes())
   diffQuarter := diff.Nanoseconds() / 4
 
   var traces []*xray.TraceSummary
@@ -109,7 +108,6 @@ func getTraceSummariesData(ctx context.Context, xrayClient XrayClient, query bac
   hasTokens := true
 
   for hasTokens {
-    log.DefaultLogger.Debug("getTraceSummariesData loop start")
     // Run the four parallel requests, returns when all are done
     responses, err := runRequests(ctx, xrayClient, requests, tokens)
     if err != nil {
@@ -131,12 +129,10 @@ func getTraceSummariesData(ctx context.Context, xrayClient XrayClient, query bac
     // Check if we still have at least one next token. Some requests can end paging sooner than other ones.
     hasTokens = false
     for _, t := range tokens {
-      log.DefaultLogger.Debug("getTraceSummariesData", "tokens", tokens)
       if len(t) > 0 {
         hasTokens = true
         break
       }
-      log.DefaultLogger.Debug("getTraceSummariesData no more tokens")
     }
 
     // If we have more traces and did not compute correct sampling beforehand, sample what we already have, set a new
@@ -410,10 +406,10 @@ func (dataProcessor *DataProcessor) dataframe() *data.Frame {
 		labels[dataProcessor.queryType],
 		data.NewField(labels[dataProcessor.queryType], nil, []string{}),
 		data.NewField("Count", nil, []int64{}),
-		data.NewField("Percent", nil, []float64{}),
+		data.NewField("Percent", nil, []float64{}).SetConfig(&data.FieldConfig{Unit: "percent", Decimals: aws.Uint16(2)}),
 	)
 
-	for key, value := range dataProcessor.counts {
+for key, value := range dataProcessor.counts {
 		frame.AppendRow(key, value, float64(value)/float64(dataProcessor.total)*100)
 	}
 

--- a/pkg/datasource/getAnalytics_test.go
+++ b/pkg/datasource/getAnalytics_test.go
@@ -21,9 +21,7 @@ type XrayClientMock struct {
 func NewXrayClientMock(traces ...[]*xray.TraceSummary) *XrayClientMock {
   var allTraces []*xray.TraceSummary
   for _, l := range traces {
-    for _, t := range l {
-      allTraces = append(allTraces, t)
-    }
+    allTraces = append(allTraces, l...)
   }
   return &XrayClientMock{
     traces: allTraces,

--- a/pkg/datasource/getAnalytics_test.go
+++ b/pkg/datasource/getAnalytics_test.go
@@ -1,0 +1,195 @@
+package datasource
+
+import (
+  "context"
+  "encoding/json"
+  "github.com/aws/aws-sdk-go/aws"
+  "github.com/aws/aws-sdk-go/aws/request"
+  "github.com/grafana/grafana-plugin-sdk-go/backend"
+  xray "github.com/grafana/x-ray-datasource/pkg/xray"
+  "github.com/stretchr/testify/require"
+  "math"
+  "strconv"
+  "testing"
+  "time"
+)
+
+type XrayClientMock struct {
+  traces []*xray.TraceSummary
+}
+
+func NewXrayClientMock(traces ...[]*xray.TraceSummary) *XrayClientMock {
+  var allTraces []*xray.TraceSummary
+  for _, l := range traces {
+    for _, t := range l {
+      allTraces = append(allTraces, t)
+    }
+  }
+  return &XrayClientMock{
+    traces: allTraces,
+  }
+}
+
+func (client *XrayClientMock) GetTraceSummariesPages(input *xray.GetTraceSummariesInput, fn func(*xray.GetTraceSummariesOutput, bool) bool) error {
+  return nil
+}
+
+func (client *XrayClientMock) GetTraceSummariesWithContext(ctx aws.Context, input *xray.GetTraceSummariesInput, opts ...request.Option) (*xray.GetTraceSummariesOutput, error) {
+  resp := &xray.GetTraceSummariesOutput{}
+
+  // We use ID to mark what group the trace should be in so we can simulate multiple multiple paged request as that is
+  // translated to NextToken that needs to be used to get that particular trace. There is some shenanigans because we
+  // translate 0 -> nil etc which probably could be simplified.
+  reqToken := tokenToNumber(input.NextToken)
+  nextToken := reqToken
+  for _, trace := range client.traces {
+    if trace.MatchedEventTime.After(*input.StartTime) && (trace.MatchedEventTime.Before(*input.EndTime) || trace.MatchedEventTime.Equal(*input.EndTime)) {
+      traceToken := tokenToNumber(trace.Id)
+      if reqToken == traceToken {
+        resp.TraceSummaries = append(resp.TraceSummaries, trace)
+      } else if traceToken > reqToken && (traceToken < nextToken || nextToken == reqToken) {
+        // If there are traces with different tokens, mark it as possible candidate for NextToken to be sent back.
+        nextToken = traceToken
+      }
+    }
+  }
+  if nextToken == 0 || nextToken == reqToken {
+    // There was nothing more to so we are on "last page"
+    resp.NextToken = nil
+  } else {
+    // there were some traces with higher token so send this back and let the client to request it later
+    resp.NextToken = aws.String(strconv.Itoa(nextToken))
+  }
+
+  // Simple sampling if sampling strategy is used
+  if input.SamplingStrategy != nil {
+    var sampled []*xray.TraceSummary
+    m := int(math.Floor(1 / *input.SamplingStrategy.Value))
+
+    for index, trace := range resp.TraceSummaries {
+      // Not probabilistic just simple mod so this is stable even reasonable even with small numbers
+      if index % m == 0 {
+        sampled = append(sampled, trace)
+      }
+    }
+    resp.TraceSummaries = sampled
+  }
+
+  return resp, nil
+}
+
+func tokenToNumber(token *string) int {
+  if token == nil {
+    return 0
+  }
+  t, err := strconv.Atoi(*token)
+  if err != nil {
+    panic("token needs to number")
+  }
+  return t
+}
+
+func (client *XrayClientMock) BatchGetTraces(input *xray.BatchGetTracesInput) (*xray.BatchGetTracesOutput, error) {
+  return nil, nil
+}
+
+func (client *XrayClientMock) GetTimeSeriesServiceStatisticsPagesWithContext(context aws.Context, input *xray.GetTimeSeriesServiceStatisticsInput, fn func(*xray.GetTimeSeriesServiceStatisticsOutput, bool) bool, options ...request.Option) error {
+  // We need this in these tests only to get the total count for the happy path without filter expression
+  out := &xray.GetTimeSeriesServiceStatisticsOutput{
+    TimeSeriesServiceStatistics: []*xray.TimeSeriesServiceStatistics{
+      {
+        EdgeSummaryStatistics: &xray.EdgeStatistics{
+          TotalCount: aws.Int64(int64(len(client.traces))),
+        },
+      },
+    },
+  }
+  fn(out, true)
+  return nil
+}
+
+func (client *XrayClientMock) GetInsightSummaries(input *xray.GetInsightSummariesInput) (*xray.GetInsightSummariesOutput, error) {
+  return nil, nil
+}
+
+func (client *XrayClientMock) GetGroupsPages(input *xray.GetGroupsInput, fn func(*xray.GetGroupsOutput, bool) bool) error {
+  return nil
+}
+
+
+func TestGetAnalytics(t *testing.T) {
+  t.Run("getInsightSummaries", func(t *testing.T) {
+    // This should go happy path use 0.5 sampling and return half of the traces
+    traces, err := getTraceSummariesData(context.Background(), NewXrayClientMock(
+      makeTrace("2020-09-16T00:00:01Z", "0", 100),
+      makeTrace("2020-09-16T00:00:02Z", "0", 100),
+      makeTrace("2020-09-16T00:00:03Z", "0", 100),
+      makeTrace("2020-09-16T00:00:04Z", "0", 100),
+    ), *makeQuery("", "2020-09-16T00:00:00Z", "2020-09-16T00:00:10Z"), 200)
+    require.NoError(t, err)
+    require.Equal(t, 200, len(traces))
+  })
+
+  t.Run("getInsightSummaries", func(t *testing.T) {
+    // first loop should return 600 traces which is more than 400
+    // sample those 600 to 300 (actual 299 due to probability)
+    // second loop returns 150 traces (using 0.5 sampling in the request)
+    // now we have 449 traces again and we have to sample again so we have 226 traces
+    seed = 42
+    traces, err := getTraceSummariesData(context.Background(), NewXrayClientMock(
+      makeTrace("2020-09-16T00:00:01Z", "0", 200),
+      makeTrace("2020-09-16T00:00:02Z", "1", 100),
+
+      makeTrace("2020-09-16T00:00:03Z", "0", 200),
+      makeTrace("2020-09-16T00:00:03Z", "1", 100),
+
+      makeTrace("2020-09-16T00:00:06Z", "0", 200),
+      makeTrace("2020-09-16T00:00:06Z", "1", 100),
+    ), *makeQuery("some expression", "2020-09-16T00:00:00Z", "2020-09-16T00:00:10Z"), 400)
+    require.NoError(t, err)
+    require.Equal(t, 226, len(traces))
+  })
+}
+
+func makeQuery(filter string, from string, to string) *backend.DataQuery {
+  parsedFrom, err := time.Parse(time.RFC3339 , from)
+  if err != nil {
+    panic(err)
+  }
+
+  parsedTo, err := time.Parse(time.RFC3339 , to)
+  if err != nil {
+    panic(err)
+  }
+  queryData := &GetAnalyticsQueryData{
+    Query: filter,
+  }
+  jsonData, _ := json.Marshal(queryData)
+  query := &backend.DataQuery{
+    JSON: jsonData,
+    TimeRange: backend.TimeRange{
+      From: parsedFrom,
+      To: parsedTo,
+    },
+  }
+  return query
+}
+
+func makeTrace(t string, id string, count int) []*xray.TraceSummary {
+  parsed, err := time.Parse(time.RFC3339 , t)
+  if err != nil {
+    panic(err)
+  }
+  id2 := aws.String(id)
+  if id == "0" {
+    id2 = nil
+  }
+  var traces []*xray.TraceSummary
+  for i := 0; i < count; i++ {
+    traces = append(traces, &xray.TraceSummary{
+      MatchedEventTime: aws.Time(parsed),
+      Id: id2,
+    })
+  }
+  return traces
+}


### PR DESCRIPTION
Add similar sampling logic x-ray console. This applies to Analytics views which are computed on Grafana side from TraceSummary API. As this API can be slow we want to use sampling strategy (part of the API) so it returns only sampled traces. Issue is we do not know what is the correct sampling. There are 2 cases how we go about it:
1. Simple case is when we do not have any filter expression. We use TimeSeriesStatistics API to get aggregated total count for all traces in a time range. Then we just compute the sampling based on the maxTraces limit.
2. If we have filter expression we have to dynamically adjust the sampling as we page over the results. We start with request with 100% sampling. Any time we get a page of traces from the API, we check if we are over the maxTraces limit. If we are we adjust the sampling rate by 1/2, sample traces we already have and run next request with the new sampling rate. 

Additionally this also runs 4 parallel requests by dividing the time range into 4 sections and page over each one in separate goroutine.