### PR TITLE
Use first group as default if Default not found

### DIFF
--- a/src/components/QueryEditor/useInitQuery.ts
+++ b/src/components/QueryEditor/useInitQuery.ts
@@ -13,8 +13,9 @@ export function useInitQuery(
   dataSource: XrayDataSource
 ) {
   useEffect(() => {
-    // We assume here the "Default" group is always there.
-    const defaultGroup = groups.find((g: Group) => g.GroupName === 'Default')!;
+    // We assume here the "Default" group is always there but lets fallback to first group if not. In case there are
+    // no groups we don't have to actually crash as most queryTypes don't need group to be defined
+    const defaultGroup = groups.find((g: Group) => g.GroupName === 'Default') || groups[0];
 
     // We assume that if there is no queryType during mount there should not be any query so we do not need to
     // check if query has traceId or not as we do with the QueryTypeOptions mapping.


### PR DESCRIPTION
Based on this comment I wanted to use the assert idea instead of the `!` operator but I realised that we actually don't need it. There is not hing special that would require the default group to be called "Default" and even if there are no groups, the plugin works fine as they are not even needed for the queries.