### PR TITLE
Fix readme provisioning datasource type is wrong

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,7 +199,7 @@ apiVersion: 1
 
 datasources:
   - name: X-Ray
-    type: datasource
+    type: grafana-x-ray-datasource
     jsonData:
       authType: credentials
       defaultRegion: eu-west-2
@@ -212,7 +212,7 @@ apiVersion: 1
 
 datasources:
   - name: X-Ray
-    type: datasource
+    type: grafana-x-ray-datasource
     jsonData:
       authType: keys
       defaultRegion: eu-west-2


### PR DESCRIPTION
In the readme the section about the datasource provisioning uses a wrong datasource type of `datasource`.
The correct datasource type is `grafana-x-ray-datasource`.