### PR TITLE
use latest grafana/aws-sdk

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "author": "Grafana",
   "license": "Apache-2.0",
   "devDependencies": {
-    "@grafana/aws-sdk": "0.0.24",
+    "@grafana/aws-sdk": "0.0.3",
     "@grafana/data": "7.4.0",
     "@grafana/runtime": "7.4.0",
     "@grafana/toolkit": "7.4.0",

--- a/src/plugin.json
+++ b/src/plugin.json
@@ -34,7 +34,8 @@
     "updated": "%TODAY%"
   },
   "dependencies": {
-    "grafanaVersion": "7.1.x",
+    "grafanaVersion": "7.5.0",
+    "grafanaDependency": ">=7.5.0",
     "plugins": []
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1136,14 +1136,10 @@
   resolved "https://registry.yarnpkg.com/@emotion/weak-memoize/-/weak-memoize-0.2.5.tgz#8eed982e2ee6f7f4e44c253e12962980791efd46"
   integrity sha512-6U71C2Wp7r5XtFtQzYrW5iKFT67OixrSxjI4MptCHzdSVlgabczzqLe0ZSgnub/5Kp4hSbpDB1tMytZY9pwxxA==
 
-"@grafana/aws-sdk@0.0.24":
-  version "0.0.24"
-  resolved "https://registry.yarnpkg.com/@grafana/aws-sdk/-/aws-sdk-0.0.24.tgz#30511706d5efaf52e81cadd8f933d1c21e8d1c6b"
-  integrity sha512-tKYZ5KgJn0/S+/z7KFUtcgihYC1vCpUPvDMONp8j1j02JWwUE3ivu9LDiPeWBLcicy0psUypC0mL3QG/e8prIw==
-  dependencies:
-    "@grafana/data" "7.4.0"
-    "@grafana/runtime" "7.4.0"
-    "@grafana/ui" "7.4.0"
+"@grafana/aws-sdk@0.0.3":
+  version "0.0.3"
+  resolved "https://registry.yarnpkg.com/@grafana/aws-sdk/-/aws-sdk-0.0.3.tgz#bc632c6c77971a5474acbe45847420503679fc75"
+  integrity sha512-V0PJLk+oU1C33knurXp8BkT5N2ctDu9b21zpK16vkJAs5aOiH/OaOhQ/IP9ipxYhB+b9PFjr8RXagV/8XJ8xwg==
 
 "@grafana/data@7.2.0", "@grafana/data@next":
   version "7.2.0"


### PR DESCRIPTION
Please test and verify that your normal path for authenticating the plugin works. Please also verify that the query editor looks alright and it's possible to get data from the backend.

What has changed in the aws-sdk? 
* made grafana/ui and grafana/data dev dependencies. this fixed a problem that caused the default region select to not overflow vertically
* remove dependency to grafana/runtime. instead reading config from grafanaBootData
* made it possible to opt out on ConnectionConfig legend header and endpoint field (a requirement for sigv4)
* add unit tests

The API has not changed, so there should be no need to make changes to the ConfigEditor.tsx. 
