### PR TITLE
Interpolate variables when opening panel in Explore

### DIFF
--- a/src/DataSource.test.ts
+++ b/src/DataSource.test.ts
@@ -11,7 +11,7 @@ import {
 } from '@grafana/data';
 import { XrayJsonData, XrayQuery, XrayQueryType, XrayTraceDataRaw, XrayTraceDataSegmentDocument } from './types';
 import { of } from 'rxjs';
-import { getTemplateSrv, setTemplateSrv, TemplateSrv } from '@grafana/runtime';
+import { TemplateSrv } from '@grafana/runtime';
 
 jest.mock('@grafana/runtime', () => {
   const runtime = jest.requireActual('@grafana/runtime');

--- a/src/DataSource.test.ts
+++ b/src/DataSource.test.ts
@@ -11,7 +11,7 @@ import {
 } from '@grafana/data';
 import { XrayJsonData, XrayQuery, XrayQueryType, XrayTraceDataRaw, XrayTraceDataSegmentDocument } from './types';
 import { of } from 'rxjs';
-import { TemplateSrv } from '@grafana/runtime/services/templateSrv';
+import { getTemplateSrv, setTemplateSrv, TemplateSrv } from '@grafana/runtime';
 
 jest.mock('@grafana/runtime', () => {
   const runtime = jest.requireActual('@grafana/runtime');
@@ -35,11 +35,15 @@ jest.mock('@grafana/runtime', () => {
           if (!target) {
             return '';
           }
-          if (!scopedVars) {
-            return target;
-          }
-          for (const key of Object.keys(scopedVars)) {
-            target = target!.replace(`\$${key}`, scopedVars[key].value);
+          const vars: Record<string, { value: any }> = {
+            ...scopedVars,
+            someVar: {
+              value: '200',
+            },
+          };
+          for (const key of Object.keys(vars)) {
+            target = target!.replace(`\$${key}`, vars[key].value);
+            target = target!.replace(`\${${key}}`, vars[key].value);
           }
           return target!;
         },
@@ -155,6 +159,18 @@ describe('XrayDataSource', () => {
       } as XrayQuery);
       expect(url).toBe(`https://us-east.console.aws.amazon.com/xray/home?region=us-east#/${expected}`);
     });
+  });
+
+  it('should replace variables', () => {
+    const ds = makeDatasourceWithResponse({} as any);
+    const logQuery: XrayQuery = {
+      refId: 'someRefId',
+      query: 'http.status = ${someVar}',
+    };
+
+    const interpolated = ds.interpolateVariablesInQueries([logQuery], {});
+
+    expect(interpolated[0].query).toBe(`http.status = 200`);
   });
 });
 

--- a/src/DataSource.ts
+++ b/src/DataSource.ts
@@ -8,6 +8,7 @@ import {
   DateTimeDuration,
   FieldType,
   MutableDataFrame,
+  ScopedVars,
   TimeRange,
   toDuration,
 } from '@grafana/data';
@@ -121,6 +122,21 @@ export class XrayDataSource extends DataSourceWithBackend<XrayQuery, XrayJsonDat
         '?' + urlQuery?.toString().replace(/\+/g, '%20').replace(/%3A/g, ':').replace(/%7E/g, '~')
       : '';
     return `${this.getXrayUrl(query.region)}#/${section}${queryParams}`;
+  }
+
+  interpolateVariablesInQueries(queries: XrayQuery[], scopedVars: ScopedVars): XrayQuery[] {
+    let expandedQueries = queries;
+    if (queries && queries.length) {
+      expandedQueries = queries.map((query) => {
+        const expandedQuery = {
+          ...query,
+          datasource: this.name,
+          query: getTemplateSrv().replace(query.query, scopedVars),
+        };
+        return expandedQuery;
+      });
+    }
+    return expandedQueries;
   }
 
   private getXrayUrl(region?: string): string {


### PR DESCRIPTION
Data source needs to implement a interpolateVariablesInQueries method in order to interpolate variables from dashboard so that in Explore the query is functioning.