### PR TITLE
Fix time durations after format change

### DIFF
--- a/src/utils/transform.ts
+++ b/src/utils/transform.ts
@@ -21,8 +21,6 @@ import {
 import { isPlainObject } from 'lodash';
 import { flatten } from './flatten';
 
-const MS_MULTIPLIER = 1000000;
-
 /**
  * Transforms response to format used by Grafana.
  */
@@ -49,7 +47,7 @@ export function transformTraceResponse(data: XrayTraceData): DataFrame {
         serviceName,
         serviceTags,
         spanID: segment.Document.name + segment.Document.origin,
-        startTime: segment.Document.start_time * MS_MULTIPLIER,
+        startTime: segment.Document.start_time,
         traceID: segment.Document.trace_id,
         parentSpanID: undefined,
       };
@@ -105,7 +103,7 @@ function transformSegmentDocument(
   serviceTags: TraceKeyValuePair[],
   parentId?: string
 ): TraceSpanRow {
-  const duration = document.end_time ? document.end_time * MS_MULTIPLIER - document.start_time * MS_MULTIPLIER : 0;
+  const duration = document.end_time ? document.end_time - document.start_time : 0;
   return {
     traceID: document.trace_id,
     spanID: document.id,
@@ -115,7 +113,7 @@ function transformSegmentDocument(
     operationName: document.name,
     serviceName,
     serviceTags,
-    startTime: document.start_time * MS_MULTIPLIER,
+    startTime: document.start_time,
     stackTraces: getStackTrace(document),
     tags: getTagsForSpan(document),
     errorIconColor: getIconColor(document),


### PR DESCRIPTION
We changed the format from Jaeger data structure to Grafana specific data frame but Jaeger one expects nanoseconds while Grafana now expects milliseconds resulting in wrong durations.