### PR TITLE
chore: automate new issues

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,14 @@
+# Lines starting with '#' are comments.
+# Each line is a file pattern followed by one or more owners.
+
+# More details are here: https://help.github.com/articles/about-codeowners/
+
+# The '*' pattern is global owners.
+
+# Order is important. The last matching pattern has the most precedence.
+# The folders are ordered as follows:
+
+# In each subsection folders are ordered first by depth, then alphabetically.
+# This should make it easy to add new rules without breaking existing ones.
+
+* @grafana/cloud-datasources

--- a/.github/ISSUE_TEMPLATE/1-bug_report.md
+++ b/.github/ISSUE_TEMPLATE/1-bug_report.md
@@ -1,0 +1,44 @@
+---
+name: Bug report
+about: Report a bug you found when using this plugin
+labels: ["datasource/X-Ray", "type/bug"]
+---
+
+<!--
+Please use this template to create your bug report. By providing as much info as possible you help us understand the issue, reproduce it and resolve it for you quicker. Therefore, take a couple of extra minutes to make sure you have provided all info needed.
+
+PROTIP: record your screen and attach it as a gif to showcase the issue.
+
+- Use query inspector to troubleshoot issues: https://bit.ly/2XNF6YS
+- How to record and attach gif: https://bit.ly/2Mi8T6K
+-->
+
+**What happened**:
+
+**What you expected to happen**:
+
+**How to reproduce it (as minimally and precisely as possible)**:
+
+<!--
+Example:
+
+1. Go to '...'
+2. Click on '....'
+3. Scroll down to '....'
+4. See error
+-->
+
+**Screenshots**
+
+<!--
+If applicable, add screenshots to help explain your problem.
+-->
+
+**Anything else we need to know?**:
+
+**Environment**:
+- Grafana version:
+- Plugin version:
+- OS Grafana is installed on:
+- User OS & Browser:
+- Others:

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Feature Request
+    url: https://github.com/grafana/x-ray-datasource/discussions/new
+    about: Discuss ideas for new features or changes
+  - name: Questions & Help
+    url: https://community.grafana.com
+    about: Please ask and answer questions here

--- a/.github/issue_commands.json
+++ b/.github/issue_commands.json
@@ -1,0 +1,18 @@
+[   
+    {
+      "type": "label",
+      "name": "datasource/X-Ray",
+      "action": "addToProject",
+      "addToProject": {
+        "url": "https://github.com/orgs/grafana/projects/97"
+      }
+    },
+    {
+      "type": "label",
+      "name": "type/docs",
+      "action": "addToProject",
+      "addToProject": {
+        "url": "https://github.com/orgs/grafana/projects/69"
+      }
+    }
+]

--- a/.github/workflows/issue_commands.yml
+++ b/.github/workflows/issue_commands.yml
@@ -1,0 +1,21 @@
+name: Run commands when issues are labeled
+on:
+  issues:
+    types: [labeled]
+jobs:
+  main:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Actions
+        uses: actions/checkout@v2
+        with:
+          repository: "grafana/grafana-github-actions"
+          path: ./actions
+          ref: main
+      - name: Install Actions
+        run: npm install --production --prefix ./actions
+      - name: Run Commands
+        uses: ./actions/commands
+        with:          
+          token: ${{secrets.GH_BOT_ACCESS_TOKEN}}
+          configPath: issue_commands

--- a/.github/workflows/issue_commands.yml
+++ b/.github/workflows/issue_commands.yml
@@ -2,6 +2,8 @@ name: Run commands when issues are labeled
 on:
   issues:
     types: [labeled]
+  pull_request:
+    types: [labeled]    
 jobs:
   main:
     runs-on: ubuntu-latest


### PR DESCRIPTION
- Added @grafana/cloud-datasources as codeowners
- Added templates for new bug reports and feature requests

Currently, we automatically add the label `datasource/*` to new issues.
This PR uses the existing GH action already set up to additionally add them to our GH Projects board.

Ideally, this should be done without relying on the `datasource/*` label (since now we have two places where the label is defined: `issue_commands.json` and `1-bug_report.md`) but can use what we have in place for now and come up with another way of doing this later.

**TODO:**
Need to new secret to this repository called `GH_BOT_ACCESS_TOKEN` as it is required by this action to be able to work properly