### PR TITLE
Fix deprecated use of strings.Title

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,4 +8,5 @@ require (
 	github.com/grafana/grafana-plugin-sdk-go v0.125.0
 	github.com/stretchr/testify v1.7.0
 	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c
+	golang.org/x/text v0.3.6
 )

--- a/pkg/datasource/getInsights.go
+++ b/pkg/datasource/getInsights.go
@@ -125,7 +125,7 @@ func getInsightSummary(xrayClient XrayClient, query backend.DataQuery, states []
 		responseDataFrame.AppendRow(
 			insight.InsightId,
 			getDescription(insight, rootCauseService),
-			cases.Title(language.English).String(strings.ToLower(*insight.State)),
+			cases.Title(language.Und).String(strings.ToLower(*insight.State)),
 			getCategories(aws.StringValueSlice(insight.Categories)),
 			getDuration(insight.StartTime, insight.EndTime),
 			rootCauseService,
@@ -139,7 +139,7 @@ func getInsightSummary(xrayClient XrayClient, query backend.DataQuery, states []
 
 func getCategories(categories []string) string {
 	for index, category := range categories {
-		categories[index] = cases.Title(language.English).String(strings.ToLower(category))
+		categories[index] = cases.Title(language.Und).String(strings.ToLower(category))
 	}
 	return strings.Join(categories, ", ")
 }

--- a/pkg/datasource/getInsights.go
+++ b/pkg/datasource/getInsights.go
@@ -12,6 +12,8 @@ import (
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
 	"github.com/grafana/grafana-plugin-sdk-go/backend/log"
 	"github.com/grafana/grafana-plugin-sdk-go/data"
+	"golang.org/x/text/cases"
+	"golang.org/x/text/language"
 )
 
 type GetInsightsQueryData struct {
@@ -123,7 +125,7 @@ func getInsightSummary(xrayClient XrayClient, query backend.DataQuery, states []
 		responseDataFrame.AppendRow(
 			insight.InsightId,
 			getDescription(insight, rootCauseService),
-			strings.Title(strings.ToLower(*insight.State)),
+			cases.Title(language.English).String(strings.ToLower(*insight.State)),
 			getCategories(aws.StringValueSlice(insight.Categories)),
 			getDuration(insight.StartTime, insight.EndTime),
 			rootCauseService,
@@ -137,7 +139,7 @@ func getInsightSummary(xrayClient XrayClient, query backend.DataQuery, states []
 
 func getCategories(categories []string) string {
 	for index, category := range categories {
-		categories[index] = strings.Title(strings.ToLower(category))
+		categories[index] = cases.Title(language.English).String(strings.ToLower(category))
 	}
 	return strings.Join(categories, ", ")
 }


### PR DESCRIPTION
In go 1.18, strings.Title was deprecated and our CI linter fails on its use.
cases.Title with language.Und(efined) most closely mimics the previous behavior. 