### PR TITLE
plugin.json : updated grafana dependency to >=8.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 ## v2.0.0
 _Not released yet_
 
-- Breaking Change: X-Ray data source now requires Grafana 8.0+ to run.
+- Stopping support for Grafana versions under `8.0.0`.
 
 ## v1.4.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this project will be documented in this file.
 
+## v2.0.0
+_Not released yet_
+
+- Breaking Change: X-Ray data source now requires Grafana 8.0+ to run.
+
 ## v1.4.0
 
 #### Bug fixes

--- a/src/plugin.json
+++ b/src/plugin.json
@@ -34,8 +34,7 @@
     "updated": "%TODAY%"
   },
   "dependencies": {
-    "grafanaVersion": "7.5.0",
-    "grafanaDependency": ">=7.5.0",
+    "grafanaDependency": ">=8.0.0",
     "plugins": []
   }
 }


### PR DESCRIPTION
Part of https://github.com/grafana/cloud-data-sources/issues/9

> We only want to support the two last major versions of Grafana, so we should update all our plugins so that they specify the minimum grafana version to be >=8.0.0. Releases of these plugins should be synced with grana 9.0.0 stable release (could be a few days after).