### PR TITLE
Fix Trace List with variable

### DIFF
--- a/src/components/QueryEditor/QueryEditorForm.test.tsx
+++ b/src/components/QueryEditor/QueryEditorForm.test.tsx
@@ -1,10 +1,61 @@
 import { queryTypeOptionToQueryType } from './QueryEditorForm';
 import { queryTypeOptions } from './constants';
 import { XrayQueryType } from '../../types';
+import { TemplateSrv } from '@grafana/runtime';
+import { ScopedVars, VariableModel } from '@grafana/data';
+
+jest.mock('@grafana/runtime', () => {
+  const runtime = jest.requireActual('@grafana/runtime');
+  return {
+    __esModule: true,
+    ...runtime,
+    // We need to mock DataSourceWithBackend.query as we extend it and call super(). At the same time doing
+    // query = jest.fn() would be harder to access due to how that is transpiled
+    DataSourceWithBackend: class DataSourceWithBackendMock extends runtime.DataSourceWithBackend {
+      mockQuery = jest.fn();
+      query(...args: any[]) {
+        return this.mockQuery(...args);
+      }
+    },
+    getTemplateSrv(): TemplateSrv {
+      return {
+        getVariables(): VariableModel[] {
+          return [];
+        },
+        replace(target?: string, scopedVars?: ScopedVars, format?: string | Function): string {
+          if (!target) {
+            return '';
+          }
+          const vars: Record<string, { value: any }> = {
+            ...scopedVars,
+            someVar: {
+              value: '200',
+            },
+          };
+          for (const key of Object.keys(vars)) {
+            target = target!.replace(`\$${key}`, vars[key].value);
+            target = target!.replace(`\${${key}}`, vars[key].value);
+          }
+          return target!;
+        },
+      };
+    },
+  };
+});
 
 describe('QueryEditor', () => {
   it('sets the query type to getTrace if query is a traceID', () => {
     const queryType = queryTypeOptionToQueryType([queryTypeOptions[0].value], '1-5f048fc1-4f1c9b022d6233dacd96fb84');
+    expect(queryType).toBe(XrayQueryType.getTrace);
+  });
+  it('sets the query type to getTraceSummaries if query is not a traceID', () => {
+    const queryType = queryTypeOptionToQueryType([queryTypeOptions[0].value], 'foo');
+    expect(queryType).toBe(XrayQueryType.getTraceSummaries);
+  });
+  it('sets the query type to getTrace if query is variable for a traceID', () => {
+    const queryType = queryTypeOptionToQueryType([queryTypeOptions[0].value], '$variable', {
+      variable: { text: '1-5f048fc1-4f1c9b022d6233dacd96fb84', value: '1-5f048fc1-4f1c9b022d6233dacd96fb84' },
+    });
     expect(queryType).toBe(XrayQueryType.getTrace);
   });
 });

--- a/src/components/QueryEditor/QueryEditorForm.test.tsx
+++ b/src/components/QueryEditor/QueryEditorForm.test.tsx
@@ -1,44 +1,29 @@
 import { queryTypeOptionToQueryType } from './QueryEditorForm';
 import { queryTypeOptions } from './constants';
 import { XrayQueryType } from '../../types';
-import { TemplateSrv } from '@grafana/runtime';
 import { ScopedVars, VariableModel } from '@grafana/data';
+import * as grafanaRuntime from '@grafana/runtime';
 
-jest.mock('@grafana/runtime', () => {
-  const runtime = jest.requireActual('@grafana/runtime');
+jest.spyOn(grafanaRuntime, 'getTemplateSrv').mockImplementation(() => {
   return {
-    __esModule: true,
-    ...runtime,
-    // We need to mock DataSourceWithBackend.query as we extend it and call super(). At the same time doing
-    // query = jest.fn() would be harder to access due to how that is transpiled
-    DataSourceWithBackend: class DataSourceWithBackendMock extends runtime.DataSourceWithBackend {
-      mockQuery = jest.fn();
-      query(...args: any[]) {
-        return this.mockQuery(...args);
-      }
+    getVariables(): VariableModel[] {
+      return [];
     },
-    getTemplateSrv(): TemplateSrv {
-      return {
-        getVariables(): VariableModel[] {
-          return [];
-        },
-        replace(target?: string, scopedVars?: ScopedVars, format?: string | Function): string {
-          if (!target) {
-            return '';
-          }
-          const vars: Record<string, { value: any }> = {
-            ...scopedVars,
-            someVar: {
-              value: '200',
-            },
-          };
-          for (const key of Object.keys(vars)) {
-            target = target!.replace(`\$${key}`, vars[key].value);
-            target = target!.replace(`\${${key}}`, vars[key].value);
-          }
-          return target!;
+    replace(target?: string, scopedVars?: ScopedVars, format?: string | Function): string {
+      if (!target) {
+        return '';
+      }
+      const vars: Record<string, { value: any }> = {
+        ...scopedVars,
+        someVar: {
+          value: '200',
         },
       };
+      for (const key of Object.keys(vars)) {
+        target = target!.replace(`\$${key}`, vars[key].value);
+        target = target!.replace(`\${${key}}`, vars[key].value);
+      }
+      return target!;
     },
   };
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -3841,17 +3841,10 @@ caniuse-api@^3.0.0:
     lodash.memoize "^4.1.2"
     lodash.uniq "^4.5.0"
 
-caniuse-lite@^1.0.0, caniuse-lite@^1.0.30000981, caniuse-lite@^1.0.30001109, caniuse-lite@^1.0.30001135:
-  version "1.0.30001135"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001135.tgz#995b1eb94404a3c9a0d7600c113c9bb27f2cd8aa"
-  integrity sha512-ziNcheTGTHlu9g34EVoHQdIu5g4foc8EsxMGC7Xkokmvw0dqNtX8BS8RgCgFBaAiSp2IdjvBxNdh0ssib28eVQ==
-
-caniuse-lite@^1.0.30001125, caniuse-lite@^1.0.30001259:
-  version "1.0.30001260"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001260.tgz#e3be3f34ddad735ca4a2736fa9e768ef34316270"
-  integrity sha512-Fhjc/k8725ItmrvW5QomzxLeojewxvqiYCKeFcfFEhut28IVLdpHU19dneOmltZQIE5HNbawj1HYD+1f2bM1Dg==
-  dependencies:
-    nanocolors "^0.1.0"
+caniuse-lite@^1.0.0, caniuse-lite@^1.0.30000981, caniuse-lite@^1.0.30001109, caniuse-lite@^1.0.30001125, caniuse-lite@^1.0.30001135, caniuse-lite@^1.0.30001259:
+  version "1.0.30001373"
+  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001373.tgz"
+  integrity sha512-pJYArGHrPp3TUqQzFYRmP/lwJlj8RCbVe3Gd3eJQkAV8SAC6b19XS9BjMvRdvaS8RMkaTN8ZhoHP6S1y8zzwEQ==
 
 capture-exit@^2.0.0:
   version "2.0.0"
@@ -8713,7 +8706,7 @@ nano-css@^5.2.1:
     stacktrace-js "^2.0.0"
     stylis "3.5.0"
 
-nanocolors@^0.1.0, nanocolors@^0.1.5:
+nanocolors@^0.1.5:
   version "0.1.12"
   resolved "https://registry.yarnpkg.com/nanocolors/-/nanocolors-0.1.12.tgz#8577482c58cbd7b5bb1681db4cf48f11a87fd5f6"
   integrity sha512-2nMHqg1x5PU+unxX7PGY7AuYxl2qDx7PSrTRjizr8sxdd3l/3hBuWWaki62qmtYm2U5i4Z5E7GbjlyDFhs9/EQ==

--- a/yarn.lock
+++ b/yarn.lock
@@ -3841,10 +3841,17 @@ caniuse-api@^3.0.0:
     lodash.memoize "^4.1.2"
     lodash.uniq "^4.5.0"
 
-caniuse-lite@^1.0.0, caniuse-lite@^1.0.30000981, caniuse-lite@^1.0.30001109, caniuse-lite@^1.0.30001125, caniuse-lite@^1.0.30001135, caniuse-lite@^1.0.30001259:
-  version "1.0.30001373"
-  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001373.tgz"
-  integrity sha512-pJYArGHrPp3TUqQzFYRmP/lwJlj8RCbVe3Gd3eJQkAV8SAC6b19XS9BjMvRdvaS8RMkaTN8ZhoHP6S1y8zzwEQ==
+caniuse-lite@^1.0.0, caniuse-lite@^1.0.30000981, caniuse-lite@^1.0.30001109, caniuse-lite@^1.0.30001135:
+  version "1.0.30001135"
+  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001135.tgz#995b1eb94404a3c9a0d7600c113c9bb27f2cd8aa"
+  integrity sha512-ziNcheTGTHlu9g34EVoHQdIu5g4foc8EsxMGC7Xkokmvw0dqNtX8BS8RgCgFBaAiSp2IdjvBxNdh0ssib28eVQ==
+
+caniuse-lite@^1.0.30001125, caniuse-lite@^1.0.30001259:
+  version "1.0.30001260"
+  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001260.tgz#e3be3f34ddad735ca4a2736fa9e768ef34316270"
+  integrity sha512-Fhjc/k8725ItmrvW5QomzxLeojewxvqiYCKeFcfFEhut28IVLdpHU19dneOmltZQIE5HNbawj1HYD+1f2bM1Dg==
+  dependencies:
+    nanocolors "^0.1.0"
 
 capture-exit@^2.0.0:
   version "2.0.0"
@@ -8706,7 +8713,7 @@ nano-css@^5.2.1:
     stacktrace-js "^2.0.0"
     stylis "3.5.0"
 
-nanocolors@^0.1.5:
+nanocolors@^0.1.0, nanocolors@^0.1.5:
   version "0.1.12"
   resolved "https://registry.yarnpkg.com/nanocolors/-/nanocolors-0.1.12.tgz#8577482c58cbd7b5bb1681db4cf48f11a87fd5f6"
   integrity sha512-2nMHqg1x5PU+unxX7PGY7AuYxl2qDx7PSrTRjizr8sxdd3l/3hBuWWaki62qmtYm2U5i4Z5E7GbjlyDFhs9/EQ==


### PR DESCRIPTION
The query editor uses a check for `trace id` to determine if a `Trace List` query is a `getTrace` or `getTraceSummaries` query. Previously, it did not replace variables before checking, which meant that a variable that represented a trace id would incorrectly get sorted as a `getTraceSummaries` query.

Structure-wise it would probably be better if the query function determined which type it was, but I wasn't sure we wanted to do that much restructuring.

Fixes #131 