### PR TITLE
chore: add levitate to detect breaking changes

### DIFF
--- a/.github/workflows/detect-breaking-changes.yml
+++ b/.github/workflows/detect-breaking-changes.yml
@@ -1,0 +1,17 @@
+name: Compatibility check
+on: [push, pull_request]
+
+jobs:
+  compatibilitycheck:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: "16"
+      - name: Install dependencies
+        run: yarn install
+      - name: Build plugin
+        run: yarn build
+      - name: Compatibility check
+        run: npx @grafana/levitate@latest is-compatible --path src/module.ts --target @grafana/data,@grafana/ui,@grafana/runtime


### PR DESCRIPTION
[Levitate](https://github.com/grafana/levitate) detects if the Grafana APIs your plugin is using are compatible with a certain version of Grafana.

Followed the steps to add this: https://github.com/grafana/grafana-plugin-examples/#api-compatibility