### PR TITLE
Update code coverage workflow

### DIFF
--- a/.github/workflows/code-coverage.yml
+++ b/.github/workflows/code-coverage.yml
@@ -4,7 +4,7 @@ on:
     branches-ignore: [dependabot/**]
 jobs:
   workflow-call:
-    uses: grafana/code-coverage/.github/workflows/code-coverage.yml@v0.1.10
+    uses: grafana/code-coverage/.github/workflows/code-coverage.yml@v0.1.13
     with:
-      frontend-path-regexp: 
+      frontend-path-regexp:
       backend-path-regexp: pkg\/(client|datasource)


### PR DESCRIPTION
Update cc workflow to use the latest version running in Node 16: https://github.com/grafana/code-coverage/pull/21