### PR TITLE
Small Refactor: Do not fetch account id if not on service map page

### DIFF
--- a/src/components/QueryEditor/AccountIdDropdown.tsx
+++ b/src/components/QueryEditor/AccountIdDropdown.tsx
@@ -1,0 +1,41 @@
+import { XrayDataSource } from 'DataSource';
+import { useAccountIds } from './useAccountIds';
+import { XrayQuery } from '../../types';
+import { TimeRange } from '@grafana/data';
+import { config } from '@grafana/runtime';
+import React from 'react';
+import { InlineFormLabel, MultiSelect } from '@grafana/ui';
+
+type Props = {
+  datasource: XrayDataSource;
+  query: XrayQuery;
+  range?: TimeRange;
+  onChange: (items: string[]) => void;
+};
+
+export const AccountIdDropdown = (props: Props) => {
+  const accountIds = useAccountIds(props.datasource, props.query, props.range);
+  const hasStoredAccountIdFilter = !!(props.query.accountIds && props.query.accountIds.length);
+  const showAccountIdDropdown = config.featureToggles.cloudWatchCrossAccountQuerying || hasStoredAccountIdFilter;
+
+  if (!showAccountIdDropdown) {
+    return null;
+  }
+
+  return (
+    <div className="gf-form">
+      <InlineFormLabel className="query-keyword" width="auto">
+        AccountId
+      </InlineFormLabel>
+      <MultiSelect
+        options={(accountIds || []).map((accountId: string) => ({
+          value: accountId,
+          label: accountId,
+        }))}
+        value={props.query.accountIds}
+        onChange={(items) => props.onChange(items.map((item) => item.value || ''))}
+        placeholder={'All'}
+      />
+    </div>
+  );
+};

--- a/src/components/QueryEditor/QueryEditorForm.tsx
+++ b/src/components/QueryEditor/QueryEditorForm.tsx
@@ -17,8 +17,7 @@ import {
 import { XrayDataSource } from '../../DataSource';
 import { QuerySection } from './QuerySection';
 import { XrayLinks } from './XrayLinks';
-import { getTemplateSrv, config } from '@grafana/runtime';
-import { useAccountIds } from './useAccountIds';
+import { getTemplateSrv } from '@grafana/runtime';
 import { AccountIdDropdown } from './AccountIdDropdown';
 
 function findOptionForQueryType(queryType: XrayQueryType, options: any = queryTypeOptions): QueryTypeOption[] {

--- a/src/components/QueryEditor/QueryEditorForm.tsx
+++ b/src/components/QueryEditor/QueryEditorForm.tsx
@@ -19,6 +19,7 @@ import { QuerySection } from './QuerySection';
 import { XrayLinks } from './XrayLinks';
 import { getTemplateSrv, config } from '@grafana/runtime';
 import { useAccountIds } from './useAccountIds';
+import { AccountIdDropdown } from './AccountIdDropdown';
 
 function findOptionForQueryType(queryType: XrayQueryType, options: any = queryTypeOptions): QueryTypeOption[] {
   for (const option of options) {
@@ -103,13 +104,8 @@ export function QueryEditorForm({
   useInitQuery(query, onChange, groups, allRegions, datasource);
 
   const selectedOptions = queryTypeToQueryTypeOptions(query.queryType);
-  const accountIds = useAccountIds(datasource, query, range);
   const allGroups = selectedOptions[0] === insightsOption ? [dummyAllGroup, ...groups] : groups;
   const styles = getStyles();
-  const hasStoredAccountIdFilter = !!(query.accountIds && query.accountIds.length);
-  const showAccountIdDropdown =
-    [serviceMapOption].includes(selectedOptions[0]) &&
-    (config.featureToggles.cloudWatchCrossAccountQuerying || hasStoredAccountIdFilter);
 
   return (
     <div>
@@ -184,26 +180,18 @@ export function QueryEditorForm({
           />
         </div>
 
-        {showAccountIdDropdown && (
-          <div className="gf-form">
-            <InlineFormLabel className="query-keyword" width="auto">
-              AccountId
-            </InlineFormLabel>
-            <MultiSelect
-              options={(accountIds || []).map((accountId: string) => ({
-                value: accountId,
-                label: accountId,
-              }))}
-              value={query.accountIds}
-              onChange={(items) => {
-                onChange({
-                  ...query,
-                  accountIds: items.map((item) => item.value),
-                } as any);
-              }}
-              placeholder={'All'}
-            />
-          </div>
+        {[serviceMapOption].includes(selectedOptions[0]) && (
+          <AccountIdDropdown
+            datasource={datasource}
+            query={query}
+            range={range}
+            onChange={(accountIds) =>
+              onChange({
+                ...query,
+                accountIds,
+              })
+            }
+          />
         )}
 
         <div className="gf-form">


### PR DESCRIPTION
While working on updating https://github.com/grafana/x-ray-datasource/pull/93 to support Cross Account Observability, I noticed that we were always fetching account Ids even when we weren't using them.

Right now we only use Account Ids for a dropdown that we show on queries for Service Map. 