### PR TITLE
Bump grafana/aws-sdk-react dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   "devDependencies": {
     "@babel/core": "^7.16.7",
     "@emotion/css": "^11.1.3",
-    "@grafana/aws-sdk": "0.0.42",
+    "@grafana/aws-sdk": "0.0.48",
     "@grafana/data": "9.3.2",
     "@grafana/e2e": "9.3.2",
     "@grafana/e2e-selectors": "9.3.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1495,10 +1495,20 @@
   dependencies:
     tslib "^2.4.0"
 
-"@grafana/aws-sdk@0.0.42":
-  version "0.0.42"
-  resolved "https://registry.yarnpkg.com/@grafana/aws-sdk/-/aws-sdk-0.0.42.tgz#adfb429df990374e33b1894e39f04692c0bcb71b"
-  integrity sha512-u7UyK1wA84t8L+kKjl+xKndKhTe0KGZYEj8EsQs+AK1JD1E90l4h82zEQGZmcNS5o8LdQeItvRBYPWylbcTp4A==
+"@grafana/async-query-data@0.1.4":
+  version "0.1.4"
+  resolved "https://registry.yarnpkg.com/@grafana/async-query-data/-/async-query-data-0.1.4.tgz#ac24e32822a8032dd1ee10ce7dcb8c2e276c58b0"
+  integrity sha512-3d7fm2sf5x/+JKTt4T6MSS/veB2J/YGfQp5Ck0Tbqtc5YIoI0p1JY+vFWfCstEHyVd1H0Ep/q/VSxf4VAs9YKQ==
+  dependencies:
+    tslib "^2.4.1"
+
+"@grafana/aws-sdk@0.0.48":
+  version "0.0.48"
+  resolved "https://registry.yarnpkg.com/@grafana/aws-sdk/-/aws-sdk-0.0.48.tgz#8831b7dc21d4b338b324a22bcaaccde116cd28bb"
+  integrity sha512-lh6aWRoHw0wlkFKY2Qhb3du6iElA2oOtwsMuTmr3urZPTfMhJEzCPkiA/pWYzZHmKaIeez/EYECirQ16k7pW/w==
+  dependencies:
+    "@grafana/async-query-data" "0.1.4"
+    "@grafana/experimental" "1.1.0"
 
 "@grafana/data@9.3.2":
   version "9.3.2"
@@ -1580,6 +1590,14 @@
     eslint-plugin-react-hooks "4.3.0"
     prettier "2.5.1"
     typescript "4.4.4"
+
+"@grafana/experimental@1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@grafana/experimental/-/experimental-1.1.0.tgz#36b9644b1e61c782ed42b4805c5e297f2cc3f8bf"
+  integrity sha512-pQhYhw+jB7Q+t8rLcd1jcx91BiFDNslBATJkNIgO9I2Bah+ww+2RH1hUGVoJNPL84vW7WRU7w9k/L7FJs7/L6Q==
+  dependencies:
+    "@types/uuid" "^8.3.3"
+    uuid "^8.3.2"
 
 "@grafana/faro-core@^1.0.0-beta2":
   version "1.0.0-beta4"
@@ -2984,6 +3002,11 @@
   integrity sha512-SBwbxYoyPIvxHbeHxTZX2Pe/74F/tX2/D3mMvzabdeJ25bBojfW0TyB8BHrbq/9zaaKICJZjLP+8r6AeZMFCuQ==
   dependencies:
     "@types/jest" "*"
+
+"@types/uuid@^8.3.3":
+  version "8.3.4"
+  resolved "https://registry.yarnpkg.com/@types/uuid/-/uuid-8.3.4.tgz#bd86a43617df0594787d38b735f55c805becf1bc"
+  integrity sha512-c/I8ZRb51j+pYGAu5CrFMRxqZ2ke4y2grEBO5AUjgSkSk+qT2Ea+OdWElz/OiMf5MNpn2b17kuVBwZLQJXzihw==
 
 "@types/yargs-parser@*":
   version "21.0.0"
@@ -10201,6 +10224,11 @@ tslib@^1.8.1, tslib@^1.9.3:
   version "1.14.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
   integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==
+
+tslib@^2.4.1:
+  version "2.6.1"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.6.1.tgz#fd8c9a0ff42590b25703c0acb3de3d3f4ede0410"
+  integrity sha512-t0hLfiEKfMUoqhG+U1oid7Pva4bbDPHYfJNiB7BiIjRkj1pyC++4N3huJfqY6aRH6VTB0rvtzQwjM4K6qpfOig==
 
 tsutils@^3.21.0:
   version "3.21.0"


### PR DESCRIPTION
While testing sandboxing, I got errors related to use of grafanaBootData in X-Ray's version of aws-sdk. The package has previously been updated to use config instead of grafanaBootData, so this is just to update the dependency to contain the new code.
