### PR TITLE
Prepare v2.7.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file.
 
+## 2.7.2
+
+- Fix X-Ray Service Map filter trace list query by @jamesrwhite in https://github.com/grafana/x-ray-datasource/pull/203
+
 ## 2.7.1
 
 - Update @grafana/aws-sdk to fix a bug in temporary credentials

--- a/cspell.config.json
+++ b/cspell.config.json
@@ -69,6 +69,7 @@
     "consts",
     "iwysiu",
     "idastambuk",
+    "jamesrwhite",
     "kevinwcyu",
     "sarahzinger",
     "yaelle",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "grafana-x-ray-datasource",
-  "version": "2.7.1",
+  "version": "2.7.2",
   "description": "AWS X-Ray data source",
   "scripts": {
     "build": "webpack -c ./.config/webpack/webpack.config.ts --env production",


### PR DESCRIPTION
* Bump @adobe/css-tools from 4.0.1 to 4.3.1 by @dependabot in https://github.com/grafana/x-ray-datasource/pull/199
* Use Github App credentials for issue commands workflow by @katebrenner in https://github.com/grafana/x-ray-datasource/pull/202
* Bump golang.org/x/net from 0.9.0 to 0.17.0 by @dependabot in https://github.com/grafana/x-ray-datasource/pull/205
* Don't run issue_commands flow on PRs  by @katebrenner in https://github.com/grafana/x-ray-datasource/pull/206
* Bump @babel/traverse from 7.20.10 to 7.23.2 by @dependabot in https://github.com/grafana/x-ray-datasource/pull/207
* Fix X-Ray Service Map filter trace list query by @jamesrwhite in https://github.com/grafana/x-ray-datasource/pull/203

**Full Changelog**: https://github.com/grafana/x-ray-datasource/compare/v2.7.1...v2.7.2