### PR TITLE
Migrate ConfigEditor and QueryEditor to the new form styling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to this project will be documented in this file.
 
+## 2.8.0
+
+- Migrate ConfigEditor and QueryEditor to the new form styling [#211](https://github.com/grafana/x-ray-datasource/pull/211)
+
+- Bump google.golang.org/grpc from 1.54.0 to 1.56.3 in [#210](https://github.com/grafana/x-ray-datasource/pull/210)
+
+- Support Node 18 in [201](https://github.com/grafana/x-ray-datasource/pull/201)
+
 ## 2.7.2
 
 - Fix X-Ray Service Map filter trace list query by @jamesrwhite in https://github.com/grafana/x-ray-datasource/pull/203

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "grafana-x-ray-datasource",
-  "version": "2.7.2",
+  "version": "2.8.0",
   "description": "AWS X-Ray data source",
   "scripts": {
     "build": "webpack -c ./.config/webpack/webpack.config.ts --env production",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   "devDependencies": {
     "@babel/core": "^7.16.7",
     "@emotion/css": "^11.1.3",
-    "@grafana/aws-sdk": "0.1.2",
+    "@grafana/aws-sdk": "0.3.0",
     "@grafana/data": "9.3.2",
     "@grafana/e2e": "9.3.2",
     "@grafana/e2e-selectors": "9.3.2",
@@ -76,6 +76,7 @@
     "webpack-livereload-plugin": "^3.0.2"
   },
   "dependencies": {
+    "@grafana/experimental": "1.7.3",
     "react-use": "^15.3.4",
     "tslib": "^2.2.0"
   }

--- a/src/components/ConfigEditor/ConfigEditor.tsx
+++ b/src/components/ConfigEditor/ConfigEditor.tsx
@@ -1,17 +1,18 @@
 import { AwsAuthDataSourceJsonData, AwsAuthDataSourceSecureJsonData, ConnectionConfig } from '@grafana/aws-sdk';
 import { DataSourcePluginOptionsEditorProps } from '@grafana/data';
-import React, { PureComponent } from 'react';
+import React from 'react';
 import { standardRegions } from './regions';
+import { config } from '@grafana/runtime';
 
 export type Props = DataSourcePluginOptionsEditorProps<AwsAuthDataSourceJsonData, AwsAuthDataSourceSecureJsonData>;
 
-export class ConfigEditor extends PureComponent<Props> {
-  render() {
-    return (
-      <div>
-        <ConnectionConfig {...this.props} standardRegions={standardRegions} />
-        {/* can add x-ray specific things here */}
-      </div>
-    );
-  }
+export function ConfigEditor(props: Props) {
+  const newFormStylingEnabled = config.featureToggles.awsDatasourcesNewFormStyling;
+
+  return (
+    <div className="width-30">
+      <ConnectionConfig {...props} standardRegions={standardRegions} newFormStylingEnabled={newFormStylingEnabled} />
+      {/* can add x-ray specific things here */}
+    </div>
+  );
 }

--- a/src/components/ConfigEditor/ConfigEditor.tsx
+++ b/src/components/ConfigEditor/ConfigEditor.tsx
@@ -12,7 +12,6 @@ export function ConfigEditor(props: Props) {
   return (
     <div className="width-30">
       <ConnectionConfig {...props} standardRegions={standardRegions} newFormStylingEnabled={newFormStylingEnabled} />
-      {/* can add x-ray specific things here */}
     </div>
   );
 }

--- a/src/components/QueryEditor/AccountIdDropdown.tsx
+++ b/src/components/QueryEditor/AccountIdDropdown.tsx
@@ -9,7 +9,7 @@ import { EditorField } from '@grafana/experimental';
 type Props = {
   datasource: XrayDataSource;
   query: XrayQuery;
-  newFornStylingEnabled?: boolean;
+  newFormStylingEnabled?: boolean;
   range?: TimeRange;
   onChange: (items: string[]) => void;
 };
@@ -23,7 +23,7 @@ export const AccountIdDropdown = (props: Props) => {
     return null;
   }
 
-  return props.newFornStylingEnabled ? (
+  return props.newFormStylingEnabled ? (
     <EditorField label="AccountId" className="query-keyword" htmlFor="accountId">
       <MultiSelect
         id="accountId"

--- a/src/components/QueryEditor/AccountIdDropdown.tsx
+++ b/src/components/QueryEditor/AccountIdDropdown.tsx
@@ -5,10 +5,11 @@ import { TimeRange } from '@grafana/data';
 import { config } from '@grafana/runtime';
 import React from 'react';
 import { InlineFormLabel, MultiSelect } from '@grafana/ui';
-
+import { EditorField } from '@grafana/experimental';
 type Props = {
   datasource: XrayDataSource;
   query: XrayQuery;
+  newFornStylingEnabled?: boolean;
   range?: TimeRange;
   onChange: (items: string[]) => void;
 };
@@ -22,7 +23,20 @@ export const AccountIdDropdown = (props: Props) => {
     return null;
   }
 
-  return (
+  return props.newFornStylingEnabled ? (
+    <EditorField label="AccountId" className="query-keyword" htmlFor="accountId">
+      <MultiSelect
+        id="accountId"
+        options={(accountIds || []).map((accountId: string) => ({
+          value: accountId,
+          label: accountId,
+        }))}
+        value={props.query.accountIds}
+        onChange={(items) => props.onChange(items.map((item) => item.value || ''))}
+        placeholder={'All'}
+      />
+    </EditorField>
+  ) : (
     <div className="gf-form">
       <InlineFormLabel className="query-keyword" width="auto">
         AccountId

--- a/src/components/QueryEditor/QueryEditor.test.tsx
+++ b/src/components/QueryEditor/QueryEditor.test.tsx
@@ -27,6 +27,12 @@ const defaultProps = {
   } as any,
 };
 
+const originalFormFeatureToggleValue = grafanaRuntime.config.featureToggles.awsDatasourcesNewFormStyling;
+
+const cleanupFeatureToggle = () => {
+  grafanaRuntime.config.featureToggles.awsDatasourcesNewFormStyling = originalFormFeatureToggleValue;
+};
+
 jest.mock('./XRayQueryField', () => {
   return {
     __esModule: true,
@@ -106,185 +112,197 @@ async function renderWithQuery(query: Omit<XrayQuery, 'refId'>, rerender?: any) 
 }
 
 describe('QueryEditor', () => {
-  function run(testName: string) {
-    describe(testName, () => {
-      it.each([
-        [XrayQueryType.getTrace, 'Trace List'],
-        [XrayQueryType.getTraceSummaries, 'Trace List'],
-        [XrayQueryType.getTimeSeriesServiceStatistics, 'Trace Statistics'],
-        [XrayQueryType.getAnalyticsRootCauseResponseTimeService, 'Root Cause'],
-        [XrayQueryType.getAnalyticsRootCauseResponseTimePath, 'Path'],
-        [XrayQueryType.getAnalyticsRootCauseErrorService, 'Root Cause'],
-        [XrayQueryType.getAnalyticsRootCauseErrorPath, 'Path'],
-        [XrayQueryType.getAnalyticsRootCauseErrorMessage, 'Error Message'],
-        [XrayQueryType.getAnalyticsRootCauseFaultService, 'Root Cause'],
-        [XrayQueryType.getAnalyticsRootCauseFaultPath, 'Path'],
-        [XrayQueryType.getAnalyticsRootCauseFaultMessage, 'Error Message'],
-        [XrayQueryType.getAnalyticsUser, 'End user impact'],
-        [XrayQueryType.getAnalyticsUrl, 'URL'],
-        [XrayQueryType.getAnalyticsStatusCode, 'HTTP status code'],
-        [XrayQueryType.getInsights, 'Insights'],
-        [XrayQueryType.getServiceMap, 'Service Map'],
-      ])('renders proper query type option when query type is %s', async (type, expected) => {
-        await renderWithQuery({
-          query: 'test query',
-          queryType: type as XrayQueryType,
-        });
-        expect(screen.getByText(expected)).not.toBeNull();
+  function run() {
+    it.each([
+      [XrayQueryType.getTrace, 'Trace List'],
+      [XrayQueryType.getTraceSummaries, 'Trace List'],
+      [XrayQueryType.getTimeSeriesServiceStatistics, 'Trace Statistics'],
+      [XrayQueryType.getAnalyticsRootCauseResponseTimeService, 'Root Cause'],
+      [XrayQueryType.getAnalyticsRootCauseResponseTimePath, 'Path'],
+      [XrayQueryType.getAnalyticsRootCauseErrorService, 'Root Cause'],
+      [XrayQueryType.getAnalyticsRootCauseErrorPath, 'Path'],
+      [XrayQueryType.getAnalyticsRootCauseErrorMessage, 'Error Message'],
+      [XrayQueryType.getAnalyticsRootCauseFaultService, 'Root Cause'],
+      [XrayQueryType.getAnalyticsRootCauseFaultPath, 'Path'],
+      [XrayQueryType.getAnalyticsRootCauseFaultMessage, 'Error Message'],
+      [XrayQueryType.getAnalyticsUser, 'End user impact'],
+      [XrayQueryType.getAnalyticsUrl, 'URL'],
+      [XrayQueryType.getAnalyticsStatusCode, 'HTTP status code'],
+      [XrayQueryType.getInsights, 'Insights'],
+      [XrayQueryType.getServiceMap, 'Service Map'],
+    ])('renders proper query type option when query type is %s', async (type, expected) => {
+      await renderWithQuery({
+        query: 'test query',
+        queryType: type as XrayQueryType,
+      });
+      expect(screen.getByText(expected)).not.toBeNull();
+    });
+
+    it('inits the query with query type', async () => {
+      const { onChange } = await renderWithQuery({ query: '' });
+      expect(onChange).toBeCalledWith({
+        refId: 'A',
+        query: '',
+        queryType: XrayQueryType.getTraceSummaries,
+        region: 'default',
+        group: { GroupName: 'Default', GroupARN: 'DefaultARN' },
+      });
+    });
+
+    it('shows column filter and resolution only if query type is getTimeSeriesServiceStatistics', async () => {
+      const { rerender } = await renderWithQuery({ query: '', queryType: XrayQueryType.getTraceSummaries });
+      expect(screen.queryByTestId('column-filter')).toBeNull();
+      expect(screen.queryByTestId('resolution')).toBeNull();
+
+      await renderWithQuery({ query: '', queryType: XrayQueryType.getTimeSeriesServiceStatistics }, rerender);
+      expect(screen.queryByTestId('column-filter')).not.toBeNull();
+      expect(screen.queryByTestId('resolution')).not.toBeNull();
+    });
+
+    it('hides query input if query is service map', async () => {
+      await renderWithQuery({ query: '', queryType: XrayQueryType.getServiceMap });
+      expect(screen.queryByText(/^Query$/)).toBeNull();
+    });
+
+    it('correctly changes the query type if user fills in trace id', async () => {
+      const { onChange } = await renderWithQuery({ query: '', queryType: XrayQueryType.getTraceSummaries });
+
+      const field = screen.getByTestId('query-field-mock');
+
+      fireEvent.change(field, { target: { value: '1-5f160a8b-83190adad07f429219c0e259' } });
+
+      expect(onChange.mock.calls[1][0]).toEqual({
+        refId: 'A',
+        query: '1-5f160a8b-83190adad07f429219c0e259',
+        queryType: XrayQueryType.getTrace,
+      });
+    });
+
+    it('can add and remove column filters', async () => {
+      let { onChange } = await renderWithQuery({
+        query: '',
+        columns: [],
+        queryType: XrayQueryType.getTimeSeriesServiceStatistics,
       });
 
-      it('inits the query with query type', async () => {
-        const { onChange } = await renderWithQuery({ query: '' });
-        expect(onChange).toBeCalledWith({
-          refId: 'A',
-          query: '',
-          queryType: XrayQueryType.getTraceSummaries,
-          region: 'default',
-          group: { GroupName: 'Default', GroupARN: 'DefaultARN' },
-        });
+      let select = screen.getByText('All columns');
+      fireEvent.mouseDown(select);
+      let option = screen.getByText(/Success Count/i);
+      fireEvent.click(option);
+
+      expect(onChange).toBeCalledWith({
+        refId: 'A',
+        query: '',
+        columns: ['OkCount'],
+        queryType: XrayQueryType.getTimeSeriesServiceStatistics,
       });
+    });
 
-      it('shows column filter and resolution only if query type is getTimeSeriesServiceStatistics', async () => {
-        const { rerender } = await renderWithQuery({ query: '', queryType: XrayQueryType.getTraceSummaries });
-        expect(screen.queryByTestId('column-filter')).toBeNull();
-        expect(screen.queryByTestId('resolution')).toBeNull();
-
-        await renderWithQuery({ query: '', queryType: XrayQueryType.getTimeSeriesServiceStatistics }, rerender);
-        expect(screen.queryByTestId('column-filter')).not.toBeNull();
-        expect(screen.queryByTestId('resolution')).not.toBeNull();
+    it('waits until groups and regions are loaded', async () => {
+      await act(async () => {
+        render(
+          <QueryEditor
+            {...{
+              ...defaultProps,
+              query: {
+                refId: 'A',
+              } as any,
+            }}
+            onChange={() => {}}
+          />
+        );
+        // No ideal selector but spinner does not seem to have any better thing to select by
+        expect(screen.getByText('', { selector: '.fa-spinner' })).toBeDefined();
+        await waitFor(() => expect(screen.getByText('Query')).toBeDefined());
       });
+    });
 
-      it('hides query input if query is service map', async () => {
-        await renderWithQuery({ query: '', queryType: XrayQueryType.getServiceMap });
-        expect(screen.queryByText(/^Query$/)).toBeNull();
+    it('sets the correct links based on region default', async () => {
+      renderEditorWithRegion('region1', 'default');
+      await checkLinks({
+        console: 'https://region1.console.aws.amazon.com/xray/home?region=region1#/analytics',
+        serviceMap: 'https://region1.console.aws.amazon.com/xray/home?region=region1#/service-map/',
       });
+    });
 
-      it('correctly changes the query type if user fills in trace id', async () => {
-        const { onChange } = await renderWithQuery({ query: '', queryType: XrayQueryType.getTraceSummaries });
-
-        const field = screen.getByTestId('query-field-mock');
-
-        fireEvent.change(field, { target: { value: '1-5f160a8b-83190adad07f429219c0e259' } });
-
-        expect(onChange.mock.calls[1][0]).toEqual({
-          refId: 'A',
-          query: '1-5f160a8b-83190adad07f429219c0e259',
-          queryType: XrayQueryType.getTrace,
-        });
+    it('sets the correct links based on region in query', async () => {
+      renderEditorWithRegion('region1', 'region2');
+      await checkLinks({
+        console: 'https://region2.console.aws.amazon.com/xray/home?region=region2#/analytics',
+        serviceMap: 'https://region2.console.aws.amazon.com/xray/home?region=region2#/service-map/',
       });
+    });
 
-      it('can add and remove column filters', async () => {
-        let { onChange } = await renderWithQuery({
-          query: '',
-          columns: [],
-          queryType: XrayQueryType.getTimeSeriesServiceStatistics,
-        });
-
-        let select = screen.getByText('All columns');
-        fireEvent.mouseDown(select);
-        let option = screen.getByText(/Success Count/i);
-        fireEvent.click(option);
-
-        expect(onChange).toBeCalledWith({
-          refId: 'A',
-          query: '',
-          columns: ['OkCount'],
-          queryType: XrayQueryType.getTimeSeriesServiceStatistics,
-        });
+    it('shows the accountIds in a dropdown on service map selection', async () => {
+      const mockGetAccountIdsForServiceMap = jest.fn(() => Promise.resolve(['account1', 'account2']));
+      await act(async () => {
+        render(
+          <QueryEditor
+            {...{
+              ...defaultProps,
+              datasource: {
+                ...defaultProps.datasource,
+                getAccountIdsForServiceMap: mockGetAccountIdsForServiceMap,
+              },
+              query: {
+                refId: 'A',
+                queryType: 'getServiceMap',
+                accountIds: ['account1'],
+              } as any,
+            }}
+            onChange={() => {}}
+          />
+        );
+        expect(screen.getByText('', { selector: '.fa-spinner' })).toBeDefined();
+        await waitFor(() => expect(screen.getByText('account1')).toBeDefined());
+        expect(mockGetAccountIdsForServiceMap).toHaveBeenCalled();
       });
+    });
 
-      it('waits until groups and regions are loaded', async () => {
-        await act(async () => {
-          render(
-            <QueryEditor
-              {...{
-                ...defaultProps,
-                query: {
-                  refId: 'A',
-                } as any,
-              }}
-              onChange={() => {}}
-            />
-          );
-          // No ideal selector but spinner does not seem to have any better thing to select by
-          expect(screen.getByText('', { selector: '.fa-spinner' })).toBeDefined();
-          await waitFor(() => expect(screen.getByText('Query')).toBeDefined());
-        });
-      });
-
-      it('sets the correct links based on region default', async () => {
-        renderEditorWithRegion('region1', 'default');
-        await checkLinks({
-          console: 'https://region1.console.aws.amazon.com/xray/home?region=region1#/analytics',
-          serviceMap: 'https://region1.console.aws.amazon.com/xray/home?region=region1#/service-map/',
-        });
-      });
-
-      it('sets the correct links based on region in query', async () => {
-        renderEditorWithRegion('region1', 'region2');
-        await checkLinks({
-          console: 'https://region2.console.aws.amazon.com/xray/home?region=region2#/analytics',
-          serviceMap: 'https://region2.console.aws.amazon.com/xray/home?region=region2#/service-map/',
-        });
-      });
-
-      it('shows the accountIds in a dropdown on service map selection', async () => {
-        const mockGetAccountIdsForServiceMap = jest.fn(() => Promise.resolve(['account1', 'account2']));
-        await act(async () => {
-          render(
-            <QueryEditor
-              {...{
-                ...defaultProps,
-                datasource: {
-                  ...defaultProps.datasource,
-                  getAccountIdsForServiceMap: mockGetAccountIdsForServiceMap,
-                },
-                query: {
-                  refId: 'A',
-                  queryType: 'getServiceMap',
-                  accountIds: ['account1'],
-                } as any,
-              }}
-              onChange={() => {}}
-            />
-          );
-          expect(screen.getByText('', { selector: '.fa-spinner' })).toBeDefined();
-          await waitFor(() => expect(screen.getByText('account1')).toBeDefined());
-          expect(mockGetAccountIdsForServiceMap).toHaveBeenCalled();
-        });
-      });
-
-      it('does not fetch account ids if service map is not selected', async () => {
-        const mockGetAccountIdsForServiceMap = jest.fn(() => Promise.resolve(['account1', 'account2']));
-        await act(async () => {
-          render(
-            <QueryEditor
-              {...{
-                ...defaultProps,
-                datasource: {
-                  ...defaultProps.datasource,
-                  getAccountIdsForServiceMap: mockGetAccountIdsForServiceMap,
-                },
-                query: {
-                  refId: 'A',
-                  queryType: XrayQueryType.getTrace,
-                  accountIds: [],
-                } as any,
-              }}
-              onChange={() => {}}
-            />
-          );
-          expect(screen.getByText('', { selector: '.fa-spinner' })).toBeDefined();
-          await waitForElementToBeRemoved(() => screen.getByText('', { selector: '.fa-spinner' }));
-          expect(mockGetAccountIdsForServiceMap).not.toHaveBeenCalled();
-        });
+    it('does not fetch account ids if service map is not selected', async () => {
+      const mockGetAccountIdsForServiceMap = jest.fn(() => Promise.resolve(['account1', 'account2']));
+      await act(async () => {
+        render(
+          <QueryEditor
+            {...{
+              ...defaultProps,
+              datasource: {
+                ...defaultProps.datasource,
+                getAccountIdsForServiceMap: mockGetAccountIdsForServiceMap,
+              },
+              query: {
+                refId: 'A',
+                queryType: XrayQueryType.getTrace,
+                accountIds: [],
+              } as any,
+            }}
+            onChange={() => {}}
+          />
+        );
+        expect(screen.getByText('', { selector: '.fa-spinner' })).toBeDefined();
+        await waitForElementToBeRemoved(() => screen.getByText('', { selector: '.fa-spinner' }));
+        expect(mockGetAccountIdsForServiceMap).not.toHaveBeenCalled();
       });
     });
   }
-
-  run('QueryEditorForm with awsDatasourcesNewFormStyling disabled');
-  grafanaRuntime.config.featureToggles.awsDatasourcesNewFormStyling = true;
-  run('QueryEditorForm with awsDatasourcesNewFormStyling enabled');
+  describe('QueryEditor with awsDatasourcesNewFormStyling feature toggle enabled', () => {
+    beforeAll(() => {
+      grafanaRuntime.config.featureToggles.awsDatasourcesNewFormStyling = false;
+    });
+    afterAll(() => {
+      cleanupFeatureToggle();
+    });
+    run();
+    describe('QueryEditor with awsDatasourcesNewFormStyling feature toggle enabled', () => {
+      beforeAll(() => {
+        grafanaRuntime.config.featureToggles.awsDatasourcesNewFormStyling = true;
+      });
+      afterAll(() => {
+        cleanupFeatureToggle();
+      });
+      run();
+    });
+  });
 });
 
 function makeDataSource(settings: DataSourceInstanceSettings<XrayJsonData>) {

--- a/src/components/QueryEditor/QueryEditor.test.tsx
+++ b/src/components/QueryEditor/QueryEditor.test.tsx
@@ -130,7 +130,7 @@ describe('QueryEditor', () => {
           query: 'test query',
           queryType: type as XrayQueryType,
         });
-        expect(screen.getByDisplayValue(expected)).not.toBeNull();
+        expect(screen.getByText(expected)).not.toBeNull();
       });
 
       it('inits the query with query type', async () => {

--- a/src/components/QueryEditor/QueryEditor.test.tsx
+++ b/src/components/QueryEditor/QueryEditor.test.tsx
@@ -6,32 +6,6 @@ import { XrayDataSource } from '../../DataSource';
 import { DataSourceInstanceSettings, ScopedVars, TypedVariableModel } from '@grafana/data';
 import * as grafanaRuntime from '@grafana/runtime';
 
-jest.spyOn(grafanaRuntime, 'getTemplateSrv').mockImplementation(() => {
-  return {
-    getVariables(): TypedVariableModel[] {
-      return [];
-    },
-    replace(target?: string, scopedVars?: ScopedVars, format?: string | Function): string {
-      if (!target) {
-        return '';
-      }
-      const vars: Record<string, { value: any }> = {
-        ...scopedVars,
-        someVar: {
-          value: '200',
-        },
-      };
-      for (const key of Object.keys(vars)) {
-        target = target!.replace(`\$${key}`, vars[key].value);
-        target = target!.replace(`\${${key}}`, vars[key].value);
-      }
-      return target!;
-    },
-    containsTemplate: jest.fn(),
-    updateTimeRange: jest.fn(),
-  };
-});
-
 const defaultProps = {
   onRunQuery: undefined as any,
   datasource: {
@@ -75,6 +49,38 @@ jest.mock(
   { virtual: true }
 );
 
+jest.mock('@grafana/runtime', () => ({
+  ...jest.requireActual('@grafana/runtime'),
+  getTemplateSrv: () => ({
+    getVariables(): TypedVariableModel[] {
+      return [];
+    },
+    replace(target?: string, scopedVars?: ScopedVars, format?: string | Function): string {
+      if (!target) {
+        return '';
+      }
+      const vars: Record<string, { value: any }> = {
+        ...scopedVars,
+        someVar: {
+          value: '200',
+        },
+      };
+      for (const key of Object.keys(vars)) {
+        target = target!.replace(`\$${key}`, vars[key].value);
+        target = target!.replace(`\${${key}}`, vars[key].value);
+      }
+      return target!;
+    },
+    containsTemplate: jest.fn(),
+    updateTimeRange: jest.fn(),
+  }),
+  config: {
+    featureToggles: {
+      awsDatasourcesNewFormStylingEnabled: false,
+    },
+  },
+}));
+
 async function renderWithQuery(query: Omit<XrayQuery, 'refId'>, rerender?: any) {
   const renderFunc = rerender || render;
 
@@ -100,177 +106,185 @@ async function renderWithQuery(query: Omit<XrayQuery, 'refId'>, rerender?: any) 
 }
 
 describe('QueryEditor', () => {
-  it.each([
-    [XrayQueryType.getTrace, 'Trace List'],
-    [XrayQueryType.getTraceSummaries, 'Trace List'],
-    [XrayQueryType.getTimeSeriesServiceStatistics, 'Trace Statistics'],
-    [XrayQueryType.getAnalyticsRootCauseResponseTimeService, 'Root Cause'],
-    [XrayQueryType.getAnalyticsRootCauseResponseTimePath, 'Path'],
-    [XrayQueryType.getAnalyticsRootCauseErrorService, 'Root Cause'],
-    [XrayQueryType.getAnalyticsRootCauseErrorPath, 'Path'],
-    [XrayQueryType.getAnalyticsRootCauseErrorMessage, 'Error Message'],
-    [XrayQueryType.getAnalyticsRootCauseFaultService, 'Root Cause'],
-    [XrayQueryType.getAnalyticsRootCauseFaultPath, 'Path'],
-    [XrayQueryType.getAnalyticsRootCauseFaultMessage, 'Error Message'],
-    [XrayQueryType.getAnalyticsUser, 'End user impact'],
-    [XrayQueryType.getAnalyticsUrl, 'URL'],
-    [XrayQueryType.getAnalyticsStatusCode, 'HTTP status code'],
-    [XrayQueryType.getInsights, 'Insights'],
-    [XrayQueryType.getServiceMap, 'Service Map'],
-  ])('renders proper query type option when query type is %s', async (type, expected) => {
-    await renderWithQuery({
-      query: 'test query',
-      queryType: type as XrayQueryType,
+  function run(testName: string) {
+    describe(testName, () => {
+      it.each([
+        [XrayQueryType.getTrace, 'Trace List'],
+        [XrayQueryType.getTraceSummaries, 'Trace List'],
+        [XrayQueryType.getTimeSeriesServiceStatistics, 'Trace Statistics'],
+        [XrayQueryType.getAnalyticsRootCauseResponseTimeService, 'Root Cause'],
+        [XrayQueryType.getAnalyticsRootCauseResponseTimePath, 'Path'],
+        [XrayQueryType.getAnalyticsRootCauseErrorService, 'Root Cause'],
+        [XrayQueryType.getAnalyticsRootCauseErrorPath, 'Path'],
+        [XrayQueryType.getAnalyticsRootCauseErrorMessage, 'Error Message'],
+        [XrayQueryType.getAnalyticsRootCauseFaultService, 'Root Cause'],
+        [XrayQueryType.getAnalyticsRootCauseFaultPath, 'Path'],
+        [XrayQueryType.getAnalyticsRootCauseFaultMessage, 'Error Message'],
+        [XrayQueryType.getAnalyticsUser, 'End user impact'],
+        [XrayQueryType.getAnalyticsUrl, 'URL'],
+        [XrayQueryType.getAnalyticsStatusCode, 'HTTP status code'],
+        [XrayQueryType.getInsights, 'Insights'],
+        [XrayQueryType.getServiceMap, 'Service Map'],
+      ])('renders proper query type option when query type is %s', async (type, expected) => {
+        await renderWithQuery({
+          query: 'test query',
+          queryType: type as XrayQueryType,
+        });
+        expect(screen.getByDisplayValue(expected)).not.toBeNull();
+      });
+
+      it('inits the query with query type', async () => {
+        const { onChange } = await renderWithQuery({ query: '' });
+        expect(onChange).toBeCalledWith({
+          refId: 'A',
+          query: '',
+          queryType: XrayQueryType.getTraceSummaries,
+          region: 'default',
+          group: { GroupName: 'Default', GroupARN: 'DefaultARN' },
+        });
+      });
+
+      it('shows column filter and resolution only if query type is getTimeSeriesServiceStatistics', async () => {
+        const { rerender } = await renderWithQuery({ query: '', queryType: XrayQueryType.getTraceSummaries });
+        expect(screen.queryByTestId('column-filter')).toBeNull();
+        expect(screen.queryByTestId('resolution')).toBeNull();
+
+        await renderWithQuery({ query: '', queryType: XrayQueryType.getTimeSeriesServiceStatistics }, rerender);
+        expect(screen.queryByTestId('column-filter')).not.toBeNull();
+        expect(screen.queryByTestId('resolution')).not.toBeNull();
+      });
+
+      it('hides query input if query is service map', async () => {
+        await renderWithQuery({ query: '', queryType: XrayQueryType.getServiceMap });
+        expect(screen.queryByText(/^Query$/)).toBeNull();
+      });
+
+      it('correctly changes the query type if user fills in trace id', async () => {
+        const { onChange } = await renderWithQuery({ query: '', queryType: XrayQueryType.getTraceSummaries });
+
+        const field = screen.getByTestId('query-field-mock');
+
+        fireEvent.change(field, { target: { value: '1-5f160a8b-83190adad07f429219c0e259' } });
+
+        expect(onChange.mock.calls[1][0]).toEqual({
+          refId: 'A',
+          query: '1-5f160a8b-83190adad07f429219c0e259',
+          queryType: XrayQueryType.getTrace,
+        });
+      });
+
+      it('can add and remove column filters', async () => {
+        let { onChange } = await renderWithQuery({
+          query: '',
+          columns: [],
+          queryType: XrayQueryType.getTimeSeriesServiceStatistics,
+        });
+
+        let select = screen.getByText('All columns');
+        fireEvent.mouseDown(select);
+        let option = screen.getByText(/Success Count/i);
+        fireEvent.click(option);
+
+        expect(onChange).toBeCalledWith({
+          refId: 'A',
+          query: '',
+          columns: ['OkCount'],
+          queryType: XrayQueryType.getTimeSeriesServiceStatistics,
+        });
+      });
+
+      it('waits until groups and regions are loaded', async () => {
+        await act(async () => {
+          render(
+            <QueryEditor
+              {...{
+                ...defaultProps,
+                query: {
+                  refId: 'A',
+                } as any,
+              }}
+              onChange={() => {}}
+            />
+          );
+          // No ideal selector but spinner does not seem to have any better thing to select by
+          expect(screen.getByText('', { selector: '.fa-spinner' })).toBeDefined();
+          await waitFor(() => expect(screen.getByText('Query')).toBeDefined());
+        });
+      });
+
+      it('sets the correct links based on region default', async () => {
+        renderEditorWithRegion('region1', 'default');
+        await checkLinks({
+          console: 'https://region1.console.aws.amazon.com/xray/home?region=region1#/analytics',
+          serviceMap: 'https://region1.console.aws.amazon.com/xray/home?region=region1#/service-map/',
+        });
+      });
+
+      it('sets the correct links based on region in query', async () => {
+        renderEditorWithRegion('region1', 'region2');
+        await checkLinks({
+          console: 'https://region2.console.aws.amazon.com/xray/home?region=region2#/analytics',
+          serviceMap: 'https://region2.console.aws.amazon.com/xray/home?region=region2#/service-map/',
+        });
+      });
+
+      it('shows the accountIds in a dropdown on service map selection', async () => {
+        const mockGetAccountIdsForServiceMap = jest.fn(() => Promise.resolve(['account1', 'account2']));
+        await act(async () => {
+          render(
+            <QueryEditor
+              {...{
+                ...defaultProps,
+                datasource: {
+                  ...defaultProps.datasource,
+                  getAccountIdsForServiceMap: mockGetAccountIdsForServiceMap,
+                },
+                query: {
+                  refId: 'A',
+                  queryType: 'getServiceMap',
+                  accountIds: ['account1'],
+                } as any,
+              }}
+              onChange={() => {}}
+            />
+          );
+          expect(screen.getByText('', { selector: '.fa-spinner' })).toBeDefined();
+          await waitFor(() => expect(screen.getByText('account1')).toBeDefined());
+          expect(mockGetAccountIdsForServiceMap).toHaveBeenCalled();
+        });
+      });
+
+      it('does not fetch account ids if service map is not selected', async () => {
+        const mockGetAccountIdsForServiceMap = jest.fn(() => Promise.resolve(['account1', 'account2']));
+        await act(async () => {
+          render(
+            <QueryEditor
+              {...{
+                ...defaultProps,
+                datasource: {
+                  ...defaultProps.datasource,
+                  getAccountIdsForServiceMap: mockGetAccountIdsForServiceMap,
+                },
+                query: {
+                  refId: 'A',
+                  queryType: XrayQueryType.getTrace,
+                  accountIds: [],
+                } as any,
+              }}
+              onChange={() => {}}
+            />
+          );
+          expect(screen.getByText('', { selector: '.fa-spinner' })).toBeDefined();
+          await waitForElementToBeRemoved(() => screen.getByText('', { selector: '.fa-spinner' }));
+          expect(mockGetAccountIdsForServiceMap).not.toHaveBeenCalled();
+        });
+      });
     });
-    expect(screen.getByText(expected)).not.toBeNull();
-  });
+  }
 
-  it('inits the query with query type', async () => {
-    const { onChange } = await renderWithQuery({ query: '' });
-    expect(onChange).toBeCalledWith({
-      refId: 'A',
-      query: '',
-      queryType: XrayQueryType.getTraceSummaries,
-      region: 'default',
-      group: { GroupName: 'Default', GroupARN: 'DefaultARN' },
-    });
-  });
-
-  it('shows column filter and resolution only if query type is getTimeSeriesServiceStatistics', async () => {
-    const { rerender } = await renderWithQuery({ query: '', queryType: XrayQueryType.getTraceSummaries });
-    expect(screen.queryByTestId('column-filter')).toBeNull();
-    expect(screen.queryByTestId('resolution')).toBeNull();
-
-    await renderWithQuery({ query: '', queryType: XrayQueryType.getTimeSeriesServiceStatistics }, rerender);
-    expect(screen.queryByTestId('column-filter')).not.toBeNull();
-    expect(screen.queryByTestId('resolution')).not.toBeNull();
-  });
-
-  it('hides query input if query is service map', async () => {
-    await renderWithQuery({ query: '', queryType: XrayQueryType.getServiceMap });
-    expect(screen.queryByText(/^Query$/)).toBeNull();
-  });
-
-  it('correctly changes the query type if user fills in trace id', async () => {
-    const { onChange } = await renderWithQuery({ query: '', queryType: XrayQueryType.getTraceSummaries });
-
-    const field = screen.getByTestId('query-field-mock');
-
-    fireEvent.change(field, { target: { value: '1-5f160a8b-83190adad07f429219c0e259' } });
-
-    expect(onChange.mock.calls[1][0]).toEqual({
-      refId: 'A',
-      query: '1-5f160a8b-83190adad07f429219c0e259',
-      queryType: XrayQueryType.getTrace,
-    });
-  });
-
-  it('can add and remove column filters', async () => {
-    let { onChange } = await renderWithQuery({
-      query: '',
-      columns: [],
-      queryType: XrayQueryType.getTimeSeriesServiceStatistics,
-    });
-
-    let select = screen.getByText('All columns');
-    fireEvent.mouseDown(select);
-    let option = screen.getByText(/Success Count/i);
-    fireEvent.click(option);
-
-    expect(onChange).toBeCalledWith({
-      refId: 'A',
-      query: '',
-      columns: ['OkCount'],
-      queryType: XrayQueryType.getTimeSeriesServiceStatistics,
-    });
-  });
-
-  it('waits until groups and regions are loaded', async () => {
-    await act(async () => {
-      render(
-        <QueryEditor
-          {...{
-            ...defaultProps,
-            query: {
-              refId: 'A',
-            } as any,
-          }}
-          onChange={() => {}}
-        />
-      );
-      // No ideal selector but spinner does not seem to have any better thing to select by
-      expect(screen.getByText('', { selector: '.fa-spinner' })).toBeDefined();
-      await waitFor(() => expect(screen.getByText('Query')).toBeDefined());
-    });
-  });
-
-  it('sets the correct links based on region default', async () => {
-    renderEditorWithRegion('region1', 'default');
-    await checkLinks({
-      console: 'https://region1.console.aws.amazon.com/xray/home?region=region1#/analytics',
-      serviceMap: 'https://region1.console.aws.amazon.com/xray/home?region=region1#/service-map/',
-    });
-  });
-
-  it('sets the correct links based on region in query', async () => {
-    renderEditorWithRegion('region1', 'region2');
-    await checkLinks({
-      console: 'https://region2.console.aws.amazon.com/xray/home?region=region2#/analytics',
-      serviceMap: 'https://region2.console.aws.amazon.com/xray/home?region=region2#/service-map/',
-    });
-  });
-
-  it('shows the accountIds in a dropdown on service map selection', async () => {
-    const mockGetAccountIdsForServiceMap = jest.fn(() => Promise.resolve(['account1', 'account2']));
-    await act(async () => {
-      render(
-        <QueryEditor
-          {...{
-            ...defaultProps,
-            datasource: {
-              ...defaultProps.datasource,
-              getAccountIdsForServiceMap: mockGetAccountIdsForServiceMap,
-            },
-            query: {
-              refId: 'A',
-              queryType: 'getServiceMap',
-              accountIds: ['account1'],
-            } as any,
-          }}
-          onChange={() => {}}
-        />
-      );
-      expect(screen.getByText('', { selector: '.fa-spinner' })).toBeDefined();
-      await waitFor(() => expect(screen.getByText('account1')).toBeDefined());
-      expect(mockGetAccountIdsForServiceMap).toHaveBeenCalled();
-    });
-  });
-
-  it('does not fetch account ids if service map is not selected', async () => {
-    const mockGetAccountIdsForServiceMap = jest.fn(() => Promise.resolve(['account1', 'account2']));
-    await act(async () => {
-      render(
-        <QueryEditor
-          {...{
-            ...defaultProps,
-            datasource: {
-              ...defaultProps.datasource,
-              getAccountIdsForServiceMap: mockGetAccountIdsForServiceMap,
-            },
-            query: {
-              refId: 'A',
-              queryType: XrayQueryType.getTrace,
-              accountIds: [],
-            } as any,
-          }}
-          onChange={() => {}}
-        />
-      );
-      expect(screen.getByText('', { selector: '.fa-spinner' })).toBeDefined();
-      await waitForElementToBeRemoved(() => screen.getByText('', { selector: '.fa-spinner' }));
-      expect(mockGetAccountIdsForServiceMap).not.toHaveBeenCalled();
-    });
-  });
+  run('QueryEditorForm with awsDatasourcesNewFormStyling disabled');
+  grafanaRuntime.config.featureToggles.awsDatasourcesNewFormStyling = true;
+  run('QueryEditorForm with awsDatasourcesNewFormStyling enabled');
 });
 
 function makeDataSource(settings: DataSourceInstanceSettings<XrayJsonData>) {

--- a/src/components/QueryEditor/QueryEditor.tsx
+++ b/src/components/QueryEditor/QueryEditor.tsx
@@ -1,8 +1,10 @@
 import React from 'react';
 import { Spinner } from '@grafana/ui';
 import { useGroups } from './useGroups';
-import { QueryEditorForm, XrayQueryEditorFormProps } from './QueryEditorForm';
 import { useRegions } from './useRegions';
+import { QueryEditorFormOld, XrayQueryEditorFormProps } from './QueryEditorFormOld';
+import { config } from '@grafana/runtime';
+import { QueryEditorForm } from './QueryEditorForm';
 /**
  * Simple wrapper that is only responsible to load groups and delay actual render of the QueryEditorForm. Main reason
  * for that is that there is queryInit code that requires groups to be already loaded and is separate hook and it
@@ -10,6 +12,8 @@ import { useRegions } from './useRegions';
  * alternatives.
  */
 export function QueryEditor(props: Omit<XrayQueryEditorFormProps, 'groups' | 'regions'>) {
+  const newFormStylingEnabled = config.featureToggles.awsDatasourcesNewFormStyling;
+
   const regions = useRegions(props.datasource);
   // Use groups will return old groups after region change so it does not flash loading state. in case datasource
   // changes regions will return undefined so that will do the loading state.
@@ -20,6 +24,10 @@ export function QueryEditor(props: Omit<XrayQueryEditorFormProps, 'groups' | 're
   if (!(groups && regions)) {
     return <Spinner />;
   } else {
-    return <QueryEditorForm {...{ ...props, groups, regions }} />;
+    return newFormStylingEnabled ? (
+      <QueryEditorForm {...{ ...props, groups, regions }} />
+    ) : (
+      <QueryEditorFormOld {...{ ...props, groups, regions }} />
+    );
   }
 }

--- a/src/components/QueryEditor/QueryEditorFormOld.tsx
+++ b/src/components/QueryEditor/QueryEditorFormOld.tsx
@@ -9,7 +9,7 @@ import {
   dummyAllGroup,
   insightsOption,
   QueryTypeOption,
-  queryTypeOptionsOld,
+  queryTypeOptions,
   serviceMapOption,
   traceListOption,
   traceStatisticsOption,
@@ -20,7 +20,7 @@ import { AccountIdDropdown } from './AccountIdDropdown';
 import { QuerySectionOld } from './QuerySectionOld';
 import { XrayLinksOld } from './XrayLinksOld';
 
-function findOptionForQueryType(queryType: XrayQueryType, options: any = queryTypeOptionsOld): QueryTypeOption[] {
+function findOptionForQueryType(queryType: XrayQueryType, options: any = queryTypeOptions): QueryTypeOption[] {
   for (const option of options) {
     const selected: QueryTypeOption[] = [];
     if (option.queryType === queryType) {
@@ -67,7 +67,7 @@ export function queryTypeOptionToQueryType(selected: string[], query: string, sc
   } else {
     let found: any = undefined;
     for (const path of selected) {
-      found = (found?.children ?? queryTypeOptionsOld).find((option: QueryTypeOption) => option.value === path);
+      found = (found?.children ?? queryTypeOptions).find((option: QueryTypeOption) => option.value === path);
     }
     return found.queryType;
   }
@@ -146,7 +146,7 @@ export function QueryEditorFormOld({
           </InlineFormLabel>
           <ButtonCascader
             value={selectedOptions.map((option) => option.value)}
-            options={queryTypeOptionsOld}
+            options={queryTypeOptions}
             onChange={(value) => {
               const newQueryType = queryTypeOptionToQueryType(value, query.query || '', data?.request?.scopedVars);
               onChange({

--- a/src/components/QueryEditor/QueryEditorFormOld.tsx
+++ b/src/components/QueryEditor/QueryEditorFormOld.tsx
@@ -1,0 +1,267 @@
+import React from 'react';
+import { css } from '@emotion/css';
+import { QueryEditorProps, ScopedVars } from '@grafana/data';
+import { ButtonCascader, InlineFormLabel, MultiSelect, Segment, stylesFactory, Select } from '@grafana/ui';
+import { Group, Region, XrayJsonData, XrayQuery, XrayQueryType } from '../../types';
+import { useInitQuery } from './useInitQuery';
+import {
+  columnNames,
+  dummyAllGroup,
+  insightsOption,
+  QueryTypeOption,
+  queryTypeOptionsOld,
+  serviceMapOption,
+  traceListOption,
+  traceStatisticsOption,
+} from './constants';
+import { XrayDataSource } from '../../DataSource';
+import { getTemplateSrv } from '@grafana/runtime';
+import { AccountIdDropdown } from './AccountIdDropdown';
+import { QuerySectionOld } from './QuerySectionOld';
+import { XrayLinksOld } from './XrayLinksOld';
+
+function findOptionForQueryType(queryType: XrayQueryType, options: any = queryTypeOptionsOld): QueryTypeOption[] {
+  for (const option of options) {
+    const selected: QueryTypeOption[] = [];
+    if (option.queryType === queryType) {
+      selected.push(option);
+      return selected;
+    }
+    if (option.children) {
+      const found = findOptionForQueryType(queryType, option.children);
+      if (found.length) {
+        selected.push(option, ...found);
+        return selected;
+      }
+    }
+  }
+  return [];
+}
+
+/**
+ * We do some mapping of the actual queryTypes to options user can select. Mainly don't want user to choose
+ * between trace list and single trace and we detect that based on query. So trace list option returns single trace
+ * if query contains single traceID.
+ */
+function queryTypeToQueryTypeOptions(queryType?: XrayQueryType): QueryTypeOption[] {
+  if (!queryType || queryType === XrayQueryType.getTimeSeriesServiceStatistics) {
+    return [traceStatisticsOption];
+  }
+
+  if (queryType === XrayQueryType.getTrace || queryType === XrayQueryType.getTraceSummaries) {
+    return [traceListOption];
+  }
+
+  if (queryType === XrayQueryType.getInsights) {
+    return [insightsOption];
+  }
+
+  return findOptionForQueryType(queryType);
+}
+
+export function queryTypeOptionToQueryType(selected: string[], query: string, scopedVars?: ScopedVars): XrayQueryType {
+  if (selected[0] === traceListOption.value) {
+    const resolvedQuery = getTemplateSrv().replace(query, scopedVars);
+    const isTraceIdQuery = /^\d-\w{8}-\w{24}$/.test(resolvedQuery.trim());
+    return isTraceIdQuery ? XrayQueryType.getTrace : XrayQueryType.getTraceSummaries;
+  } else {
+    let found: any = undefined;
+    for (const path of selected) {
+      found = (found?.children ?? queryTypeOptionsOld).find((option: QueryTypeOption) => option.value === path);
+    }
+    return found.queryType;
+  }
+}
+
+const getStyles = stylesFactory(() => ({
+  queryParamsRow: css`
+    flex-wrap: wrap;
+  `,
+  spring: css`
+    flex: 1;
+  `,
+  regionSelect: css`
+    margin-right: 4px;
+  `,
+}));
+
+export type XrayQueryEditorFormProps = QueryEditorProps<XrayDataSource, XrayQuery, XrayJsonData> & {
+  groups: Group[];
+  regions: Region[];
+};
+export function QueryEditorFormOld({
+  query,
+  onChange,
+  datasource,
+  onRunQuery,
+  groups,
+  range,
+  regions,
+  data,
+}: XrayQueryEditorFormProps) {
+  const allRegions = [{ label: 'default', value: 'default', text: 'default' }, ...regions];
+  useInitQuery(query, onChange, groups, allRegions, datasource);
+
+  const selectedOptions = queryTypeToQueryTypeOptions(query.queryType);
+  const allGroups = selectedOptions[0] === insightsOption ? [dummyAllGroup, ...groups] : groups;
+  const styles = getStyles();
+
+  return (
+    <div>
+      {![insightsOption, serviceMapOption].includes(selectedOptions[0]) && (
+        <div className="gf-form">
+          <QuerySectionOld
+            query={query}
+            datasource={datasource}
+            onChange={onChange}
+            onRunQuery={onRunQuery}
+            selectedOptions={selectedOptions}
+          />
+        </div>
+      )}
+      <div className={`gf-form ${styles.queryParamsRow}`}>
+        <div className="gf-form">
+          <InlineFormLabel className="query-keyword" width="auto">
+            Region
+          </InlineFormLabel>
+          <Select
+            className={styles.regionSelect}
+            options={allRegions}
+            value={query.region}
+            onChange={(v) =>
+              onChange({
+                ...query,
+                region: v.value,
+              })
+            }
+            width={18}
+            placeholder="Choose Region"
+            menuPlacement="bottom"
+            maxMenuHeight={500}
+          />
+        </div>
+        <div className="gf-form">
+          <InlineFormLabel className="query-keyword" width="auto">
+            Query Type
+          </InlineFormLabel>
+          <ButtonCascader
+            value={selectedOptions.map((option) => option.value)}
+            options={queryTypeOptionsOld}
+            onChange={(value) => {
+              const newQueryType = queryTypeOptionToQueryType(value, query.query || '', data?.request?.scopedVars);
+              onChange({
+                ...query,
+                queryType: newQueryType,
+                columns: newQueryType === XrayQueryType.getTimeSeriesServiceStatistics ? ['all'] : undefined,
+              } as any);
+            }}
+          >
+            {selectedOptions[selectedOptions.length - 1].label}
+          </ButtonCascader>
+        </div>
+
+        <div className="gf-form">
+          <InlineFormLabel className="query-keyword" width="auto">
+            Group
+          </InlineFormLabel>
+          <Segment
+            value={query.group?.GroupName}
+            options={allGroups.map((group: Group) => ({
+              value: group.GroupARN,
+              label: group.GroupName,
+            }))}
+            onChange={(value) => {
+              onChange({
+                ...query,
+                group: allGroups.find((g: Group) => g.GroupARN === value.value),
+              } as any);
+            }}
+          />
+        </div>
+
+        {[serviceMapOption].includes(selectedOptions[0]) && (
+          <AccountIdDropdown
+            datasource={datasource}
+            query={query}
+            range={range}
+            onChange={(accountIds) =>
+              onChange({
+                ...query,
+                accountIds,
+              })
+            }
+          />
+        )}
+
+        <div className="gf-form">
+          {selectedOptions[0] === insightsOption && (
+            <div className="gf-form">
+              <InlineFormLabel className="query-keyword" width="auto">
+                State
+              </InlineFormLabel>
+              <Segment
+                value={query.state ?? 'All'}
+                options={['All', 'Active', 'Closed'].map((val) => ({ value: val, label: val }))}
+                onChange={(value) => {
+                  onChange({
+                    ...query,
+                    state: value.value,
+                  });
+                }}
+              />
+            </div>
+          )}
+        </div>
+
+        <div className="gf-form">
+          {selectedOptions[0] === traceStatisticsOption && (
+            <div className="gf-form" data-testid="resolution" style={{ flexWrap: 'wrap' }}>
+              <InlineFormLabel className="query-keyword" width="auto">
+                Resolution
+              </InlineFormLabel>
+              <Segment
+                value={query.resolution ? query.resolution.toString() + 's' : 'auto'}
+                options={['auto', '60s', '300s'].map((val) => ({ value: val, label: val }))}
+                onChange={({ value }) => {
+                  onChange({
+                    ...query,
+                    resolution: value === 'auto' ? undefined : parseInt(value!, 10),
+                  } as any);
+                }}
+              />
+            </div>
+          )}
+        </div>
+
+        {/* spring to push the sections apart */}
+        <div className={styles.spring} />
+        <XrayLinksOld datasource={datasource} query={query} range={range} />
+      </div>
+      {selectedOptions[0] === traceStatisticsOption && (
+        <div className="gf-form" data-testid="column-filter" style={{ flexWrap: 'wrap' }}>
+          <InlineFormLabel className="query-keyword" width="auto">
+            Columns
+          </InlineFormLabel>
+          <div style={{ flex: 1 }}>
+            <MultiSelect
+              allowCustomValue={false}
+              options={Object.keys(columnNames).map((c) => ({
+                label: columnNames[c],
+                value: c,
+              }))}
+              value={(query.columns || []).map((c) => ({
+                label: columnNames[c],
+                value: c,
+              }))}
+              onChange={(values) => onChange({ ...query, columns: values.map((v) => v.value!) })}
+              closeMenuOnSelect={false}
+              isClearable={true}
+              placeholder="All columns"
+              menuPlacement="bottom"
+            />
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/QueryEditor/QuerySection.tsx
+++ b/src/components/QueryEditor/QuerySection.tsx
@@ -1,32 +1,31 @@
-import { Icon, InlineFormLabel, stylesFactory, Tooltip } from '@grafana/ui';
 import { XRayQueryField } from './XRayQueryField';
 import React from 'react';
-import { queryTypeOptionToQueryType } from './QueryEditorForm';
 import { XrayDataSource } from '../../DataSource';
 import { css } from '@emotion/css';
 import { XrayQuery } from '../../types';
 import { QueryTypeOption } from './constants';
+import { EditorField } from '@grafana/experimental';
+import { queryTypeOptionToQueryType } from './QueryEditorForm';
 
-const getStyles = stylesFactory(() => ({
-  tooltipLink: css`
-    color: #33a2e5;
-    &:hover {
-      color: #33a2e5;
-      filter: brightness(120%);
-    }
-  `,
-}));
+const styles = {
+  tooltipLink: css({
+    color: '#33a2e5',
+    '&:hover': {
+      color: ' #33a2e5',
+      filter: 'brightness(120%)',
+    },
+  }),
+};
 
 type Props = {
   query: XrayQuery;
   datasource: XrayDataSource;
   onChange: (value: XrayQuery) => void;
   onRunQuery: () => void;
-  selectedOptions: QueryTypeOption[];
+  selectedOption: QueryTypeOption;
 };
 export function QuerySection(props: Props) {
-  const { datasource, query, onRunQuery, onChange, selectedOptions } = props;
-  const styles = getStyles();
+  const { datasource, query, onRunQuery, onChange, selectedOption } = props;
 
   const onRunQueryLocal = () => {
     onChange(query);
@@ -37,30 +36,25 @@ export function QuerySection(props: Props) {
   };
 
   return (
-    <div style={{ flex: 1, display: 'flex' }}>
-      <InlineFormLabel className="query-keyword" width="auto">
-        Query&nbsp;
-        <Tooltip
-          placement="top"
-          content={
-            <span>
-              See{' '}
-              <a
-                href="https://docs.aws.amazon.com/xray/latest/devguide/xray-console-filters.html?icmpid=docs_xray_console"
-                target="_blank"
-                rel="noreferrer"
-                className={styles.tooltipLink}
-              >
-                X-Ray documentation
-              </a>{' '}
-              for filter expression help.
-            </span>
-          }
-          theme="info"
-        >
-          <Icon className="gf-form-help-icon gf-form-help-icon--right-normal" name="info-circle" size="sm" />
-        </Tooltip>
-      </InlineFormLabel>
+    <EditorField
+      label="Query"
+      tooltipInteractive
+      width="100%"
+      tooltip={
+        <span>
+          See{' '}
+          <a
+            href="https://docs.aws.amazon.com/xray/latest/devguide/xray-console-filters.html?icmpid=docs_xray_console"
+            target="_blank"
+            rel="noreferrer"
+            className={styles.tooltipLink}
+          >
+            X-Ray documentation
+          </a>{' '}
+          for filter expression help.
+        </span>
+      }
+    >
       <XRayQueryField
         query={query}
         history={[]}
@@ -69,14 +63,11 @@ export function QuerySection(props: Props) {
         onChange={(e) => {
           onChange({
             ...query,
-            queryType: queryTypeOptionToQueryType(
-              selectedOptions.map((option) => option.value),
-              e.query
-            ),
+            queryType: queryTypeOptionToQueryType(selectedOption.value, e.query),
             query: e.query,
           });
         }}
       />
-    </div>
+    </EditorField>
   );
 }

--- a/src/components/QueryEditor/QuerySection.tsx
+++ b/src/components/QueryEditor/QuerySection.tsx
@@ -22,10 +22,10 @@ type Props = {
   datasource: XrayDataSource;
   onChange: (value: XrayQuery) => void;
   onRunQuery: () => void;
-  selectedOption: QueryTypeOption;
+  selectedOptions: QueryTypeOption[];
 };
 export function QuerySection(props: Props) {
-  const { datasource, query, onRunQuery, onChange, selectedOption } = props;
+  const { datasource, query, onRunQuery, onChange, selectedOptions } = props;
 
   const onRunQueryLocal = () => {
     onChange(query);
@@ -63,7 +63,10 @@ export function QuerySection(props: Props) {
         onChange={(e) => {
           onChange({
             ...query,
-            queryType: queryTypeOptionToQueryType(selectedOption.value, e.query),
+            queryType: queryTypeOptionToQueryType(
+              selectedOptions.map((option) => option.value),
+              e.query
+            ),
             query: e.query,
           });
         }}

--- a/src/components/QueryEditor/QuerySectionOld.tsx
+++ b/src/components/QueryEditor/QuerySectionOld.tsx
@@ -1,0 +1,82 @@
+import { Icon, InlineFormLabel, stylesFactory, Tooltip } from '@grafana/ui';
+import { XRayQueryField } from './XRayQueryField';
+import React from 'react';
+import { XrayDataSource } from '../../DataSource';
+import { css } from '@emotion/css';
+import { XrayQuery } from '../../types';
+import { QueryTypeOption } from './constants';
+import { queryTypeOptionToQueryType } from './QueryEditorFormOld';
+
+const getStyles = stylesFactory(() => ({
+  tooltipLink: css`
+    color: #33a2e5;
+    &:hover {
+      color: #33a2e5;
+      filter: brightness(120%);
+    }
+  `,
+}));
+
+type Props = {
+  query: XrayQuery;
+  datasource: XrayDataSource;
+  onChange: (value: XrayQuery) => void;
+  onRunQuery: () => void;
+  selectedOptions: QueryTypeOption[];
+};
+export function QuerySectionOld(props: Props) {
+  const { datasource, query, onRunQuery, onChange, selectedOptions } = props;
+  const styles = getStyles();
+
+  const onRunQueryLocal = () => {
+    onChange(query);
+    // Only run query if it has value
+    if (query.query) {
+      onRunQuery();
+    }
+  };
+
+  return (
+    <div style={{ flex: 1, display: 'flex' }}>
+      <InlineFormLabel className="query-keyword" width="auto">
+        Query&nbsp;
+        <Tooltip
+          placement="top"
+          content={
+            <span>
+              See{' '}
+              <a
+                href="https://docs.aws.amazon.com/xray/latest/devguide/xray-console-filters.html?icmpid=docs_xray_console"
+                target="_blank"
+                rel="noreferrer"
+                className={styles.tooltipLink}
+              >
+                X-Ray documentation
+              </a>{' '}
+              for filter expression help.
+            </span>
+          }
+          theme="info"
+        >
+          <Icon className="gf-form-help-icon gf-form-help-icon--right-normal" name="info-circle" size="sm" />
+        </Tooltip>
+      </InlineFormLabel>
+      <XRayQueryField
+        query={query}
+        history={[]}
+        datasource={datasource}
+        onRunQuery={onRunQueryLocal}
+        onChange={(e) => {
+          onChange({
+            ...query,
+            queryType: queryTypeOptionToQueryType(
+              selectedOptions.map((option) => option.value),
+              e.query
+            ),
+            query: e.query,
+          });
+        }}
+      />
+    </div>
+  );
+}

--- a/src/components/QueryEditor/XrayLinksOld.tsx
+++ b/src/components/QueryEditor/XrayLinksOld.tsx
@@ -1,27 +1,25 @@
-import { useTheme2 } from '@grafana/ui';
+import { stylesFactory } from '@grafana/ui';
 import { css } from '@emotion/css';
 import { XrayDataSource } from '../../DataSource';
 import { XrayQuery } from '../../types';
-import { GrafanaTheme2, TimeRange } from '@grafana/data';
+import { TimeRange } from '@grafana/data';
 import React from 'react';
 
-const getStyles = (theme: GrafanaTheme2) => ({
-  container: css({ display: 'flex', paddingTop: theme.spacing(3) }),
-  link: css({
-    whiteSpace: 'nowrap',
-    backgroundColor: theme.colors.background.primary,
-    color: theme.colors.text.primary,
-  }),
-});
+const getStyles = stylesFactory(() => ({
+  container: css`
+    display: flex;
+  `,
+  link: css`
+    white-space: nowrap;
+  `,
+}));
 type XrayLinksProps = {
   datasource: XrayDataSource;
   query: XrayQuery;
   range?: TimeRange;
 };
-export function XrayLinks({ datasource, query, range }: XrayLinksProps) {
-  const theme = useTheme2();
-  const styles = getStyles(theme);
-
+export function XrayLinksOld({ datasource, query, range }: XrayLinksProps) {
+  const styles = getStyles();
   return (
     <div className={styles.container}>
       {[

--- a/src/components/QueryEditor/constants.ts
+++ b/src/components/QueryEditor/constants.ts
@@ -25,7 +25,7 @@ export const traceStatisticsOption: QueryTypeOption = {
   queryType: XrayQueryType.getTimeSeriesServiceStatistics,
 };
 
-export const queryTypeOptionsOld: QueryTypeOption[] = [
+export const queryTypeOptions: QueryTypeOption[] = [
   traceListOption,
   traceStatisticsOption,
   insightsOption,
@@ -78,98 +78,6 @@ export const queryTypeOptionsOld: QueryTypeOption[] = [
             value: 'fault',
             label: 'Fault',
             children: [
-              {
-                value: 'rootCauseService',
-                label: 'Root Cause',
-                queryType: XrayQueryType.getAnalyticsRootCauseFaultService,
-              },
-              {
-                value: 'path',
-                label: 'Path',
-                queryType: XrayQueryType.getAnalyticsRootCauseFaultPath,
-              },
-              {
-                value: 'message',
-                label: 'Error Message',
-                queryType: XrayQueryType.getAnalyticsRootCauseFaultMessage,
-              },
-            ],
-          },
-        ],
-      },
-      {
-        value: 'user',
-        label: 'End user impact',
-        queryType: XrayQueryType.getAnalyticsUser,
-      } as QueryTypeOption,
-      {
-        value: 'url',
-        label: 'URL',
-        queryType: XrayQueryType.getAnalyticsUrl,
-      },
-      {
-        value: 'statusCode',
-        label: 'HTTP status code',
-        queryType: XrayQueryType.getAnalyticsStatusCode,
-      },
-    ],
-  },
-  serviceMapOption,
-];
-
-export const queryTypeOptions: QueryTypeOption[] = [
-  traceListOption,
-  traceStatisticsOption,
-  insightsOption,
-  {
-    label: 'Trace Analytics',
-    value: 'traceAnalytics',
-    items: [
-      {
-        value: 'rootCause',
-        label: 'Root Cause',
-        items: [
-          {
-            value: 'responseTime',
-            label: 'Response Time',
-            items: [
-              {
-                value: 'rootCauseService',
-                label: 'Root Cause',
-                queryType: XrayQueryType.getAnalyticsRootCauseResponseTimeService,
-              } as QueryTypeOption,
-              {
-                value: 'path',
-                label: 'Path',
-                queryType: XrayQueryType.getAnalyticsRootCauseResponseTimePath,
-              },
-            ],
-          },
-          {
-            value: 'error',
-            label: 'Error',
-            items: [
-              {
-                value: 'rootCauseService',
-                label: 'Root Cause',
-                queryType: XrayQueryType.getAnalyticsRootCauseErrorService,
-              },
-              {
-                value: 'path',
-                label: 'Path',
-                queryType: XrayQueryType.getAnalyticsRootCauseErrorPath,
-              },
-              {
-                value: 'message',
-                label: 'Error Message',
-                queryType: XrayQueryType.getAnalyticsRootCauseErrorMessage,
-              },
-            ],
-          },
-          {
-            value: 'fault',
-            label: 'Fault',
-            items: [
               {
                 value: 'rootCauseService',
                 label: 'Root Cause',

--- a/src/components/QueryEditor/constants.ts
+++ b/src/components/QueryEditor/constants.ts
@@ -4,6 +4,7 @@ import { CascaderOption } from '@grafana/ui';
 export type QueryTypeOption = CascaderOption & {
   queryType?: XrayQueryType;
   children?: QueryTypeOption[];
+  items?: QueryTypeOption[];
 };
 
 export const traceListOption: QueryTypeOption = { label: 'Trace List', value: 'traceList' };
@@ -24,7 +25,7 @@ export const traceStatisticsOption: QueryTypeOption = {
   queryType: XrayQueryType.getTimeSeriesServiceStatistics,
 };
 
-export const queryTypeOptions: QueryTypeOption[] = [
+export const queryTypeOptionsOld: QueryTypeOption[] = [
   traceListOption,
   traceStatisticsOption,
   insightsOption,
@@ -77,6 +78,98 @@ export const queryTypeOptions: QueryTypeOption[] = [
             value: 'fault',
             label: 'Fault',
             children: [
+              {
+                value: 'rootCauseService',
+                label: 'Root Cause',
+                queryType: XrayQueryType.getAnalyticsRootCauseFaultService,
+              },
+              {
+                value: 'path',
+                label: 'Path',
+                queryType: XrayQueryType.getAnalyticsRootCauseFaultPath,
+              },
+              {
+                value: 'message',
+                label: 'Error Message',
+                queryType: XrayQueryType.getAnalyticsRootCauseFaultMessage,
+              },
+            ],
+          },
+        ],
+      },
+      {
+        value: 'user',
+        label: 'End user impact',
+        queryType: XrayQueryType.getAnalyticsUser,
+      } as QueryTypeOption,
+      {
+        value: 'url',
+        label: 'URL',
+        queryType: XrayQueryType.getAnalyticsUrl,
+      },
+      {
+        value: 'statusCode',
+        label: 'HTTP status code',
+        queryType: XrayQueryType.getAnalyticsStatusCode,
+      },
+    ],
+  },
+  serviceMapOption,
+];
+
+export const queryTypeOptions: QueryTypeOption[] = [
+  traceListOption,
+  traceStatisticsOption,
+  insightsOption,
+  {
+    label: 'Trace Analytics',
+    value: 'traceAnalytics',
+    items: [
+      {
+        value: 'rootCause',
+        label: 'Root Cause',
+        items: [
+          {
+            value: 'responseTime',
+            label: 'Response Time',
+            items: [
+              {
+                value: 'rootCauseService',
+                label: 'Root Cause',
+                queryType: XrayQueryType.getAnalyticsRootCauseResponseTimeService,
+              } as QueryTypeOption,
+              {
+                value: 'path',
+                label: 'Path',
+                queryType: XrayQueryType.getAnalyticsRootCauseResponseTimePath,
+              },
+            ],
+          },
+          {
+            value: 'error',
+            label: 'Error',
+            items: [
+              {
+                value: 'rootCauseService',
+                label: 'Root Cause',
+                queryType: XrayQueryType.getAnalyticsRootCauseErrorService,
+              },
+              {
+                value: 'path',
+                label: 'Path',
+                queryType: XrayQueryType.getAnalyticsRootCauseErrorPath,
+              },
+              {
+                value: 'message',
+                label: 'Error Message',
+                queryType: XrayQueryType.getAnalyticsRootCauseErrorMessage,
+              },
+            ],
+          },
+          {
+            value: 'fault',
+            label: 'Fault',
+            items: [
               {
                 value: 'rootCauseService',
                 label: 'Root Cause',

--- a/yarn.lock
+++ b/yarn.lock
@@ -1621,13 +1621,13 @@
   dependencies:
     tslib "^2.4.1"
 
-"@grafana/aws-sdk@0.1.2":
-  version "0.1.2"
-  resolved "https://registry.yarnpkg.com/@grafana/aws-sdk/-/aws-sdk-0.1.2.tgz#5eda0c2814b91610dddc51510f81ae141f44030b"
-  integrity sha512-IZDBFWHPuX8LotJl26RMzHu6gLX6e3SE132EYgDwHSSMQ6fZLFY/t1fy39flG119CLckvsg2oIuKdctrgwVowA==
+"@grafana/aws-sdk@0.3.0":
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/@grafana/aws-sdk/-/aws-sdk-0.3.0.tgz#302fb8841ba870eb89a9195fa6fcb891604539ae"
+  integrity sha512-UyldLMZLoUwYg77VD/hqbXkfrtbh2osQT3WNpybtHQwLwa1qCaIQB7yntVBv1g+eevrOFnhItqOJRMJoXxBYEQ==
   dependencies:
     "@grafana/async-query-data" "0.1.4"
-    "@grafana/experimental" "1.1.0"
+    "@grafana/experimental" "1.7.0"
 
 "@grafana/data@9.3.2":
   version "9.3.2"
@@ -1708,12 +1708,21 @@
     eslint-plugin-react-hooks "4.6.0"
     typescript "4.8.4"
 
-"@grafana/experimental@1.1.0":
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/@grafana/experimental/-/experimental-1.1.0.tgz#36b9644b1e61c782ed42b4805c5e297f2cc3f8bf"
-  integrity sha512-pQhYhw+jB7Q+t8rLcd1jcx91BiFDNslBATJkNIgO9I2Bah+ww+2RH1hUGVoJNPL84vW7WRU7w9k/L7FJs7/L6Q==
+"@grafana/experimental@1.7.0":
+  version "1.7.0"
+  resolved "https://registry.yarnpkg.com/@grafana/experimental/-/experimental-1.7.0.tgz#f05ce178f3201cd5268645eb14dc5bcfefa05a4c"
+  integrity sha512-3DfDzGTUnvG/v2U0lhBaB05j4x0bczrgylrg5Co6LMyRYh1kPA4XnK0dTshSxA6igjKqAjSacfwZQ40f4rLdqw==
   dependencies:
     "@types/uuid" "^8.3.3"
+    uuid "^8.3.2"
+
+"@grafana/experimental@1.7.3":
+  version "1.7.3"
+  resolved "https://registry.yarnpkg.com/@grafana/experimental/-/experimental-1.7.3.tgz#a07399fda8dc602bffe85bb57b8a7ae209a5ee92"
+  integrity sha512-Un9L8KNQTkTYyNKAJAr0rOG/MjjgS6/oD5eY4p3VWlKiUe89K2JNXTMH3Bbj4oMTU8EC+x8tEcAohbVjUPqIcw==
+  dependencies:
+    "@types/uuid" "^8.3.3"
+    semver "^7.5.4"
     uuid "^8.3.2"
 
 "@grafana/faro-core@^1.0.0-beta2":


### PR DESCRIPTION
This migrates X-Ray Config and Query editors to the new form styling. The old styling is preserved and the new one is added under a feature toggle: awsDatasourcesNewFormStyling 

### Config Editor:
<img width="300" alt="Screenshot 2023-10-26 at 4 00 24 PM" src="https://github.com/grafana/x-ray-datasource/assets/16140639/5a2b6895-73b1-4dde-bb6f-fd36d56b2bd5">   <img width="300" alt="Screenshot 2023-10-26 at 4 06 14 PM" src="https://github.com/grafana/x-ray-datasource/assets/16140639/1a75d87a-d451-4453-94d5-2f8dfeeb1a08">

- Upgraded aws-sdk-react to use the new ConnectionConfig and passed the feature flag value

### Query Editor
<img width="1337" alt="Screenshot 2023-10-26 at 4 00 39 PM" src="https://github.com/grafana/x-ray-datasource/assets/16140639/1d05a44a-416f-4a53-83f0-de22bef4ee83">

https://github.com/grafana/x-ray-datasource/assets/16140639/0a90b280-a31c-4d60-9777-9cc83502327d


- changed the order of the input so that query type comes the first at the top. Since, depending on the query types, different form inputs are rendered, I found this looked better and less 'jumpy' above the query type selector. 
- uses Editor components from grafana/experimental
- moved the old styling components to `{componentName}Old` so they can be easily removed when we remove the feature flag
- tested in grafana 8.4.11, 9.4.7 and latest main