### PR TITLE
Fix: pass empty array to query all columns

### DIFF
--- a/src/components/QueryEditor/QueryEditorForm.tsx
+++ b/src/components/QueryEditor/QueryEditorForm.tsx
@@ -125,7 +125,7 @@ export function QueryEditorForm({
                 onChange({
                   ...query,
                   queryType: newQueryType,
-                  columns: newQueryType === XrayQueryType.getTimeSeriesServiceStatistics ? ['all'] : undefined,
+                  columns: newQueryType === XrayQueryType.getTimeSeriesServiceStatistics ? [] : undefined,
                 } as any);
               }}
             >

--- a/src/components/QueryEditor/QueryEditorFormOld.tsx
+++ b/src/components/QueryEditor/QueryEditorFormOld.tsx
@@ -152,7 +152,7 @@ export function QueryEditorFormOld({
               onChange({
                 ...query,
                 queryType: newQueryType,
-                columns: newQueryType === XrayQueryType.getTimeSeriesServiceStatistics ? ['all'] : undefined,
+                columns: newQueryType === XrayQueryType.getTimeSeriesServiceStatistics ? [] : undefined,
               } as any);
             }}
           >


### PR DESCRIPTION
Fixes e2e tests running on the latest grafana dev images. There was a recent change in the base select component that would allow custom values that were passed in programmatically, while still disallowing custom values entered by the user. This change made it so the `'all'` value was now included in the multi-select component for selecting which columns to query by default, even though it's not a valid column to select by. This would cause all the columns to be queried, even if you only wanted to query by one column (which is what the e2e test was testing for). The preferred way to query all columns is to pass an empty array (see this [comment](https://github.com/grafana/x-ray-datasource/blob/efd0d0698764fc9cf24ef601fe88931b194d15ec/pkg/datasource/getTimeSeriesServiceStatistics.go#L100-L101) in the backend in the Trace Statistics query handler) so this change matches that.

Fixes: #227 