### PR TITLE
Fix: use ReadAuthSettings to get authSettings

### DIFF
--- a/pkg/datasource/datasource.go
+++ b/pkg/datasource/datasource.go
@@ -47,7 +47,7 @@ func NewDatasource(ctx context.Context, xrayClientFactory XrayClientFactory, set
 	resMux.HandleFunc("/accounts", ds.GetAccounts)
 	ds.ResourceMux = httpadapter.New(resMux)
 
-	authSettings, _ := awsds.ReadAuthSettingsFromContext(ctx)
+	authSettings := awsds.ReadAuthSettings(ctx)
 	ds.authSettings = *authSettings
 	ds.sessions = awsds.NewSessionCache()
 	return ds


### PR DESCRIPTION
Uses ReadAuthSettings which tries to read auth settings from context first and then automatically falls back to reading auth settings from the environment.

Added a comment in https://github.com/grafana/x-ray-datasource/pull/234 to add this to the changelog in that PR