### PR TITLE
Update plugin name to match Amazon convention

### DIFF
--- a/src/plugin.json
+++ b/src/plugin.json
@@ -1,6 +1,6 @@
 {
   "type": "datasource",
-  "name": "X-Ray",
+  "name": "AWS X-Ray",
   "id": "grafana-x-ray-datasource",
   "category": "tracing",
   "metrics": true,
@@ -9,7 +9,7 @@
   "alerting": true,
   "executable": "gpx_x-ray-datasource",
   "info": {
-    "description": "Data source for Amazon AWS X-Ray",
+    "description": "Data source for AWS X-Ray",
     "author": {
       "name": "Grafana",
       "url": "grafana.com"


### PR DESCRIPTION
The plugin should show in the catalog as "AWS X-Ray", not just "X-Ray".