### PR TITLE
Chore: Update plugin.json keywords

### DIFF
--- a/src/plugin.json
+++ b/src/plugin.json
@@ -14,7 +14,7 @@
       "name": "Grafana",
       "url": "grafana.com"
     },
-    "keywords": ["aws", "x-ray", "tracing", "cloud provider", "traces"],
+    "keywords": ["datasource", "aws", "amazon", "x-ray", "tracing", "cloud provider", "traces"],
     "logos": {
       "small": "img/AWS-X-Ray.svg",
       "large": "img/AWS-X-Ray.svg"


### PR DESCRIPTION
Update plugin.json keywords to include "amazon" + "datasource"

Related to https://github.com/grafana/oss-plugin-partnerships/issues/1055