### PR TITLE
Add PDC support

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "react": "18.3.1",
     "react-dom": "18.3.1",
     "react-router-dom": "^7.1.1",
+    "semver": "^7.6.3",
     "tslib": "2.8.1"
   },
   "devDependencies": {
@@ -54,6 +55,7 @@
     "@types/node": "^22.10.2",
     "@types/prismjs": "1.26.5",
     "@types/react-router-dom": "^5.2.0",
+    "@types/semver": "^7.5.8",
     "@types/slate": "0.47.16",
     "@typescript-eslint/eslint-plugin": "^8.18.2",
     "@typescript-eslint/parser": "^8.18.2",
@@ -80,7 +82,6 @@
     "replace-in-file-webpack-plugin": "^1.0.6",
     "sass": "1.83.0",
     "sass-loader": "16.0.4",
-    "semver": "^7.6.3",
     "style-loader": "4.0.0",
     "swc-loader": "^0.2.3",
     "terser-webpack-plugin": "^5.3.11",

--- a/src/components/ConfigEditor/ConfigEditor.tsx
+++ b/src/components/ConfigEditor/ConfigEditor.tsx
@@ -1,6 +1,9 @@
 import { AwsAuthDataSourceJsonData, AwsAuthDataSourceSecureJsonData, ConnectionConfig } from '@grafana/aws-sdk';
 import { DataSourcePluginOptionsEditorProps } from '@grafana/data';
+import { config } from '@grafana/runtime';
+import { SecureSocksProxySettings } from '@grafana/ui';
 import React from 'react';
+import { gte } from 'semver';
 import { standardRegions } from './regions';
 
 export type Props = DataSourcePluginOptionsEditorProps<AwsAuthDataSourceJsonData, AwsAuthDataSourceSecureJsonData>;
@@ -9,6 +12,9 @@ export function ConfigEditor(props: Props) {
   return (
     <div className="width-30">
       <ConnectionConfig {...props} standardRegions={standardRegions} />
+      {config.secureSocksDSProxyEnabled && gte(config.buildInfo.version, '10.0.0') && (
+        <SecureSocksProxySettings options={props.options} onOptionsChange={props.onOptionsChange} />
+      )}
     </div>
   );
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2520,6 +2520,11 @@
   dependencies:
     csstype "^3.0.2"
 
+"@types/semver@^7.5.8":
+  version "7.5.8"
+  resolved "https://registry.yarnpkg.com/@types/semver/-/semver-7.5.8.tgz#8268a8c57a3e4abd25c165ecd36237db7948a55e"
+  integrity sha512-I8EUhyrgfLrcTkzV3TSsGyl1tSuPrEDzr0yd5m90UgNxQkyDXULk3b6MlQqTCpZpNtWe1K0hzclnZkTcLBe2UQ==
+
 "@types/sizzle@*":
   version "2.3.9"
   resolved "https://registry.yarnpkg.com/@types/sizzle/-/sizzle-2.3.9.tgz#d4597dbd4618264c414d7429363e3f50acb66ea2"


### PR DESCRIPTION
Fixes https://github.com/grafana/oss-plugin-partnerships/issues/1128

[Instructions for testing PDC locally](https://wiki.grafana-ops.net/w/index.php/Engineering/Grafana/Data_Sources/API_servers/Testing_datasources_with_PDC_Locally)

New secure socks proxy setting added below the region selector in the config page

<img width="484" alt="x-ray" src="https://github.com/user-attachments/assets/94da2075-d373-43e1-a3cd-1a216d59a688" />
