### PR TITLE
Add start time to response

### DIFF
--- a/pkg/datasource/datasource_test.go
+++ b/pkg/datasource/datasource_test.go
@@ -83,6 +83,7 @@ func makeSummary(region string) *xray.TraceSummary {
 	return &xray.TraceSummary{
 		Annotations: annotations,
 		Duration:    aws.Float64(10.5),
+		StartTime:   aws.Time(time.Date(2023, time.January, 1, 12, 0, 0, 0, time.UTC)),
 		Http:        http,
 		Id:          aws.String(traceId),
 		ErrorRootCauses: []*xray.ErrorRootCause{
@@ -516,9 +517,10 @@ func TestDatasource(t *testing.T) {
 		frame := response.Responses["A"].Frames[0]
 		require.Equal(t, 2, frame.Fields[0].Len())
 		require.Equal(t, "id1", *frame.Fields[0].At(0).(*string))
-		require.Equal(t, "GET", *frame.Fields[1].At(0).(*string))
-		require.Equal(t, 10.5, *frame.Fields[3].At(0).(*float64))
-		require.Equal(t, int64(3), *frame.Fields[6].At(0).(*int64))
+		require.Equal(t, time.Date(2023, time.January, 1, 12, 0, 0, 0, time.UTC), *frame.Fields[1].At(0).(*time.Time))
+		require.Equal(t, "GET", *frame.Fields[2].At(0).(*string))
+		require.Equal(t, 10.5, *frame.Fields[4].At(0).(*float64))
+		require.Equal(t, int64(3), *frame.Fields[7].At(0).(*int64))
 	})
 	t.Run("getTraceSummaries query with region", func(t *testing.T) {
 		response, err := queryDatasource(ds, datasource.QueryGetTraceSummaries, datasource.GetTraceSummariesQueryData{Query: "", Region: "us-east-1"})

--- a/pkg/datasource/getTraceSummaries.go
+++ b/pkg/datasource/getTraceSummaries.go
@@ -3,6 +3,7 @@ package datasource
 import (
 	"context"
 	"encoding/json"
+	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/xray"
@@ -35,6 +36,7 @@ func (ds *Datasource) getTraceSummariesForSingleQuery(ctx context.Context, query
 	responseDataFrame := data.NewFrame(
 		"TraceSummaries",
 		data.NewField("Id", nil, []*string{}),
+		data.NewField("Start Time", nil, []*time.Time{}),
 		data.NewField("Method", nil, []*string{}),
 		data.NewField("Response", nil, []*int64{}),
 		data.NewField("Response Time", nil, []*float64{}).SetConfig(&data.FieldConfig{Unit: "s"}),
@@ -62,6 +64,7 @@ func (ds *Datasource) getTraceSummariesForSingleQuery(ctx context.Context, query
 
 			responseDataFrame.AppendRow(
 				summary.Id,
+				summary.StartTime,
 				summary.Http.HttpMethod,
 				summary.Http.HttpStatus,
 				summary.Duration,

--- a/src/XRayDataSource.test.ts
+++ b/src/XRayDataSource.test.ts
@@ -4,7 +4,6 @@ import {
   DataQueryRequest,
   DataSourceInstanceSettings,
   FieldType,
-  MutableDataFrame,
   NodeGraphDataFrameFieldNames,
   ScopedVars,
   TypedVariableModel,
@@ -494,65 +493,76 @@ function makeServiceMapWithLinkedEdge() {
 }
 
 function makeTraceSummariesResponse(): DataFrame {
-  return new MutableDataFrame({
+  return {
     name: 'TraceSummaries',
+    length: 2,
+
     fields: [
       {
         name: 'Id',
         type: FieldType.string,
         values: ['12345', '67890'],
+        config: {},
       },
       {
         name: 'Duration',
         type: FieldType.number,
         values: [10, 20],
+        config: {},
       },
     ],
-  });
+  };
 }
 
 function makeInsightResponse(): DataFrame {
-  return new MutableDataFrame({
+  return {
     name: 'InsightSummaries',
+    length: 2,
     fields: [
       {
         name: 'InsightId',
         type: FieldType.string,
         values: ['12345', '67890', 'sss'],
+        config: {},
       },
       {
         name: 'Duration',
         type: FieldType.number,
         values: [4590000, 1422000, 42000],
+        config: {},
       },
     ],
-  });
+  };
 }
 
 function makeServiceMapResponse(): DataFrame {
-  return new MutableDataFrame({
+  return {
     name: 'ServiceMap',
+    length: 5,
     fields: [
       {
         name: 'Service',
         type: FieldType.string,
         values: makeServiceMapWithLinkedEdge(),
+        config: {},
       },
     ],
-  });
+  };
 }
 
 function makeTraceResponse(trace: XrayTraceDataRaw): DataFrame {
-  return new MutableDataFrame({
+  return {
     name: 'Traces',
+    length: trace.Segments.length,
     fields: [
       {
         name: 'traces',
         type: FieldType.trace,
         values: [JSON.stringify(trace)],
+        config: {},
       },
     ],
-  });
+  };
 }
 
 function makeDatasourceWithResponse(response: DataFrame): XrayDataSource {

--- a/tests/query-editor.spec.ts
+++ b/tests/query-editor.spec.ts
@@ -13,6 +13,7 @@ test('data query is successful when `Trace List` query is valid', async ({ page,
   await expect(panelEditPage.panel.getErrorIcon()).not.toBeVisible();
   await expect(panelEditPage.panel.fieldNames).toHaveText([
     'Id',
+    'Start Time',
     'Method',
     'Response',
     'Response Time',


### PR DESCRIPTION
We had a user [request](https://github.com/grafana/x-ray-datasource/issues/281) to add the trace `Start Time` to the Trace list response, which makes sense to me. We're just passing what we get from AWS as `time` field which gets parsed to a user-readable format.

Also fixed some deprecation warnings for ArrayVector and MutableDataFrame

<img width="800" alt="Screenshot 2025-01-02 at 16 46 53" src="https://github.com/user-attachments/assets/bce66116-40a3-4545-b2f2-caae7b0e8770" />



