### PR TITLE
Update readme to include info on Compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+# Compatibility
+
+Grafana AWS X-Ray data source plugin >=2.13.0 is not compatible with Grafana versions <10.4.x due to a breaking change in UI components.
+
 # X-Ray data source
 
 X-Ray datasource plugin provides a support for [AWS X-Ray](https://aws.amazon.com/xray/). Add it as a data source, then you are ready to


### PR DESCRIPTION
We released 2.13.0  with the plugin-ui migration which isn't supported when plugin runs in Grafana<10.4.0, but I failed to update the readme about compatibility. 