### PR TITLE
Auto convert w3c trace format (#184)

### DIFF
--- a/pkg/datasource/datasource_test.go
+++ b/pkg/datasource/datasource_test.go
@@ -182,7 +182,7 @@ func (client *XrayClientMock) BatchGetTraces(input *xray.BatchGetTracesInput) (*
 			Traces: []*xray.Trace{},
 		}, nil
 	}
-	traceId := "trace1"
+	traceId := *input.TraceIds[0]
 	if client.queryCalledWithRegion != "" {
 		traceId = traceId + "-" + client.queryCalledWithRegion
 	}
@@ -398,7 +398,7 @@ func TestDatasource(t *testing.T) {
 	})
 
 	t.Run("getTrace query", func(t *testing.T) {
-		response, err := queryDatasource(ds, datasource.QueryGetTrace, datasource.GetTraceQueryData{Query: "traceID"})
+		response, err := queryDatasource(ds, datasource.QueryGetTrace, datasource.GetTraceQueryData{Query: "trace1"})
 		require.NoError(t, err)
 		require.NoError(t, response.Responses["A"].Error)
 
@@ -414,12 +414,34 @@ func TestDatasource(t *testing.T) {
 	})
 
 	t.Run("getTrace query with different region", func(t *testing.T) {
-		response, err := queryDatasource(ds, datasource.QueryGetTrace, datasource.GetTraceQueryData{Query: "traceID", Region: "us-east-1"})
+		response, err := queryDatasource(ds, datasource.QueryGetTrace, datasource.GetTraceQueryData{Query: "trace1", Region: "us-east-1"})
 		require.NoError(t, err)
 		require.NoError(t, response.Responses["A"].Error)
 		require.JSONEq(
 			t,
 			"{\"Duration\":1,\"Id\":\"trace1-us-east-1\",\"LimitExceeded\":null,\"Segments\":[{\"Document\":\"{}\",\"Id\":\"segment1\"}]}",
+			response.Responses["A"].Frames[0].Fields[0].At(0).(string),
+		)
+	})
+
+	t.Run("getTrace query with W3C format trace ID", func(t *testing.T) {
+		// Use a valid W3C format trace ID (32 hex characters)
+		w3cTraceID := "1234567890abcdef1234567890abcdef"
+
+		response, err := queryDatasource(ds, datasource.QueryGetTrace, datasource.GetTraceQueryData{Query: w3cTraceID})
+		require.NoError(t, err)
+		require.NoError(t, response.Responses["A"].Error)
+
+		// Verify we get correct frames
+		require.Equal(t, 2, len(response.Responses["A"].Frames))
+		require.Equal(t, "TraceGraph", response.Responses["A"].Frames[1].Name)
+		require.Equal(t, 1, response.Responses["A"].Frames[1].Fields[0].Len())
+		require.Equal(t, 1, response.Responses["A"].Frames[0].Fields[0].Len())
+
+		// Verify that the trace ID was correctly converted from W3C format to X-Ray format
+		require.JSONEq(
+			t,
+			"{\"Duration\":1,\"Id\":\"1-12345678-90abcdef1234567890abcdef\",\"LimitExceeded\":null,\"Segments\":[{\"Document\":\"{}\",\"Id\":\"segment1\"}]}",
 			response.Responses["A"].Frames[0].Fields[0].At(0).(string),
 		)
 	})

--- a/pkg/datasource/getTrace.go
+++ b/pkg/datasource/getTrace.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"strings"
 	"sync"
 
 	"github.com/aws/aws-sdk-go/service/xray"
@@ -16,6 +17,21 @@ import (
 type GetTraceQueryData struct {
 	Query  string `json:"query"`
 	Region string `json:"region"`
+}
+
+// isW3CTraceID checks if the trace ID is in W3C format
+func isW3CTraceID(traceID string) bool {
+	// W3C trace IDs are 32 hex characters (16 bytes)
+	return len(traceID) == 32 && !strings.Contains(traceID, "-")
+}
+
+// convertW3CToXRayTraceID converts a W3C format trace ID to X-Ray format
+func convertW3CToXRayTraceID(w3cTraceID string) string {
+	// X-Ray format: 1-{8 chars}-{24 chars}
+	if len(w3cTraceID) == 32 {
+		return fmt.Sprintf("1-%s-%s", w3cTraceID[0:8], w3cTraceID[8:])
+	}
+	return w3cTraceID
 }
 
 // getSingleTrace returns single trace from BatchGetTraces API and unmarshals it.
@@ -32,7 +48,14 @@ func (ds *Datasource) getSingleTrace(ctx context.Context, query backend.DataQuer
 		return errorsource.Response(err)
 	}
 
-	log.DefaultLogger.Debug("getSingleTrace", "RefID", query.RefID, "query", queryData.Query, "region", queryData.Region)
+	// Handle W3C format trace IDs by converting to X-Ray format
+	traceID := queryData.Query
+	if isW3CTraceID(traceID) {
+		traceID = convertW3CToXRayTraceID(traceID)
+		log.DefaultLogger.Debug("Converted W3C trace ID to X-Ray format", "original", queryData.Query, "converted", traceID)
+	}
+
+	log.DefaultLogger.Debug("getSingleTrace", "RefID", query.RefID, "query", queryData.Query, "traceID", traceID, "region", queryData.Region)
 
 	var wg sync.WaitGroup
 	var tracesResponse *xray.BatchGetTracesOutput
@@ -47,7 +70,7 @@ func (ds *Datasource) getSingleTrace(ctx context.Context, query backend.DataQuer
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
-		tracesResponse, tracesError = xrayClient.BatchGetTraces(&xray.BatchGetTracesInput{TraceIds: []*string{&queryData.Query}})
+		tracesResponse, tracesError = xrayClient.BatchGetTraces(&xray.BatchGetTracesInput{TraceIds: []*string{&traceID}})
 	}()
 
 	// We get the trace graph in parallel but if this fails we still return the trace
@@ -55,7 +78,7 @@ func (ds *Datasource) getSingleTrace(ctx context.Context, query backend.DataQuer
 	go func() {
 		defer wg.Done()
 		traceGraphError = xrayClient.GetTraceGraphPages(
-			&xray.GetTraceGraphInput{TraceIds: []*string{&queryData.Query}},
+			&xray.GetTraceGraphInput{TraceIds: []*string{&traceID}},
 			func(page *xray.GetTraceGraphOutput, _ bool) bool {
 				for _, service := range page.Services {
 					bytes, err := json.Marshal(service)

--- a/src/components/QueryEditor/QueryEditor.test.tsx
+++ b/src/components/QueryEditor/QueryEditor.test.tsx
@@ -151,7 +151,7 @@ describe('QueryEditor', () => {
     expect(screen.queryByText(/^Query$/)).toBeNull();
   });
 
-  it('correctly changes the query type if user fills in trace id', async () => {
+  it('correctly changes the query type if user fills in trace id (X-Ray format)', async () => {
     const { onChange } = await renderWithQuery({ query: '', queryType: XrayQueryType.getTraceSummaries });
 
     const field = screen.getByTestId('query-field-mock');
@@ -161,6 +161,20 @@ describe('QueryEditor', () => {
     expect(onChange.mock.calls[1][0]).toEqual({
       refId: 'A',
       query: '1-5f160a8b-83190adad07f429219c0e259',
+      queryType: XrayQueryType.getTrace,
+    });
+  });
+
+  it('correctly changes the query type if user fills in trace id (W3C format)', async () => {
+    const { onChange } = await renderWithQuery({ query: '', queryType: XrayQueryType.getTraceSummaries });
+
+    const field = screen.getByTestId('query-field-mock');
+
+    fireEvent.change(field, { target: { value: '5f160a8b83190adad07f429219c0e259' } });
+
+    expect(onChange.mock.calls[1][0]).toEqual({
+      refId: 'A',
+      query: '5f160a8b83190adad07f429219c0e259',
       queryType: XrayQueryType.getTrace,
     });
   });

--- a/src/components/QueryEditor/QueryEditorForm.tsx
+++ b/src/components/QueryEditor/QueryEditorForm.tsx
@@ -63,7 +63,7 @@ function queryTypeToQueryTypeOptions(queryType?: XrayQueryType): QueryTypeOption
 export function queryTypeOptionToQueryType(selected: string[], query: string, scopedVars?: ScopedVars): XrayQueryType {
   if (selected[0] === traceListOption.value) {
     const resolvedQuery = getTemplateSrv().replace(query, scopedVars);
-    const isTraceIdQuery = /^\d-\w{8}-\w{24}$/.test(resolvedQuery.trim());
+    const isTraceIdQuery = /^(\d-\w{8}-\w{24}|\w{32})$/.test(resolvedQuery.trim());
     return isTraceIdQuery ? XrayQueryType.getTrace : XrayQueryType.getTraceSummaries;
   } else {
     let found: any = undefined;


### PR DESCRIPTION
This PR implements support for automatically converting W3C Trace Context format to AWS X-Ray format. This mimics the transformation behavior available in the AWS X-Ray console and allows the plugin to interoperate more effectively with systems using the standardized W3C trace context specification.
Resolves: https://github.com/grafana/x-ray-datasource/issues/184