### PR TITLE
Chore: Migrate to Github actions

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,47 @@
+name: Plugins - CD
+run-name: Deploy ${{ inputs.branch }} to ${{ inputs.environment }} by @${{ github.actor }}
+
+on:
+  workflow_dispatch:
+    inputs:
+      branch:
+        description: Branch to publish from. Can be used to deploy PRs to dev
+        default: main
+      environment:
+        description: Environment to publish to
+        required: true
+        type: choice
+        options:
+          - "dev"
+          - "ops"
+          - "prod"
+      docs-only:
+        description: Only publish docs, do not publish the plugin
+        default: false
+        type: boolean
+
+permissions: {}
+
+jobs:
+  cd:
+    name: CD
+    uses: grafana/plugin-ci-workflows/.github/workflows/cd.yml@main # zizmor: ignore[unpinned-uses]
+    permissions:
+      contents: write
+      id-token: write
+      attestations: write
+    with:
+      branch: ${{ github.event.inputs.branch }}
+      environment: ${{ github.event.inputs.environment }}
+      docs-only: ${{ fromJSON(github.event.inputs.docs-only) }}
+      golangci-lint-version: '2.1.6'
+      # the shared workflow doesn't have a mechanism to specify custom Vault secrets in e2e tests, so we're using the workflow in e2e-tests.yml instead
+      run-playwright: false
+
+      # Scope for the plugin published to the catalog. Setting this to "grafana_cloud" will make it visible only in Grafana Cloud
+      # (and hide it for on-prem). This is required for some provisioned plugins.
+      # scopes: grafana_cloud
+
+      # Also deploy the plugin to Grafana Cloud via Argo. You also have to follow the Argo Workflows setup guide for this to work.
+      # grafana-cloud-deployment-type: provisioned
+      # argo-workflow-slack-channel: "#grafana-plugins-platform-ci"

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -1,0 +1,22 @@
+name: Plugins - CI
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+permissions: {}
+
+jobs:
+  ci:
+    name: CI
+    uses: grafana/plugin-ci-workflows/.github/workflows/ci.yml@main # zizmor: ignore[unpinned-uses]
+    permissions:
+      contents: read
+      id-token: write
+    with:
+      plugin-version-suffix: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || '' }}
+      golangci-lint-version: '2.1.6'
+      # the shared workflow doesn't have a mechanism to specify custom Vault secrets in e2e tests, so we're using the workflow in e2e-tests.yml instead
+      run-playwright: false

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ logs
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+.eslintcache
 
 node_modules/
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -83,7 +83,7 @@ You need to have commit rights to the GitHub repository to publish a release.
 1. Update the version number in the `package.json` file.
 2. Update the `CHANGELOG.md` by copy and pasting the relevant PRs from [Github's Release drafter interface](https://github.com/grafana/x-ray-datasource/releases/new) or by running `yarn generate-release-notes` (you'll need to install the [gh cli](https://cli.github.com/) and [jq](https://jqlang.github.io/jq/) to run this command).
 3. PR the changes.
-4. Once merged, follow the Drone release process that you can find [here](https://github.com/grafana/integrations-team/wiki/Plugin-Release-Process#drone-release-process)
+4. Once merged, follow the release process that you can find [here](https://enghub.grafana-ops.net/docs/default/component/grafana-plugins-platform/plugins-ci-github-actions/010-plugins-ci-github-actions/#cd_1)
 
 ## Learn more
 

--- a/cspell.config.json
+++ b/cspell.config.json
@@ -13,7 +13,8 @@
     "go.sum",
     "mage_output_file.go",
     "playwright-report",
-    "test-results"
+    "test-results",
+    ".gitignore"
   ],
   "words": [
     "awsds",

--- a/pkg/datasource/getAnalytics.go
+++ b/pkg/datasource/getAnalytics.go
@@ -4,11 +4,12 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	xraytypes "github.com/aws/aws-sdk-go-v2/service/xray/types"
 	"math"
 	"math/rand"
 	"strconv"
 	"time"
+
+	xraytypes "github.com/aws/aws-sdk-go-v2/service/xray/types"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/xray"
@@ -315,10 +316,11 @@ func (dataProcessor *DataProcessor) processSingleTrace(summary xraytypes.TraceSu
 		}
 		for _, cause := range summary.ErrorRootCauses {
 			var key string
-			if dataProcessor.queryType == QueryGetAnalyticsRootCauseErrorService {
+			switch dataProcessor.queryType {
+			case QueryGetAnalyticsRootCauseErrorService:
 				service := cause.Services[len(cause.Services)-1]
 				key = fmt.Sprintf("%s (%s)", *service.Name, *service.Type)
-			} else if dataProcessor.queryType == QueryGetAnalyticsRootCauseErrorPath {
+			case QueryGetAnalyticsRootCauseErrorPath:
 				for index, service := range cause.Services {
 					key += fmt.Sprintf("%s (%s)", *service.Name, *service.Type)
 
@@ -331,7 +333,8 @@ func (dataProcessor *DataProcessor) processSingleTrace(summary xraytypes.TraceSu
 						key += " => "
 					}
 				}
-			} else {
+
+			default:
 				key = getErrorMessage(cause)
 			}
 			dataProcessor.counts[key]++
@@ -344,10 +347,11 @@ func (dataProcessor *DataProcessor) processSingleTrace(summary xraytypes.TraceSu
 		}
 		for _, cause := range summary.FaultRootCauses {
 			var key string
-			if dataProcessor.queryType == QueryGetAnalyticsRootCauseFaultService {
+			switch dataProcessor.queryType {
+			case QueryGetAnalyticsRootCauseFaultService:
 				service := cause.Services[len(cause.Services)-1]
 				key = fmt.Sprintf("%s (%s)", *service.Name, *service.Type)
-			} else if dataProcessor.queryType == QueryGetAnalyticsRootCauseFaultPath {
+			case QueryGetAnalyticsRootCauseFaultPath:
 				for index, service := range cause.Services {
 					key += fmt.Sprintf("%s (%s)", *service.Name, *service.Type)
 
@@ -364,11 +368,11 @@ func (dataProcessor *DataProcessor) processSingleTrace(summary xraytypes.TraceSu
 						key += " => "
 					}
 				}
-			} else if dataProcessor.queryType == QueryGetAnalyticsRootCauseFaultMessage {
-				key = getFaultMessage(cause)
-			} else {
+			case QueryGetAnalyticsRootCauseFaultMessage:
+			default:
 				key = getFaultMessage(cause)
 			}
+
 			dataProcessor.counts[key]++
 			dataProcessor.total++
 		}

--- a/pkg/datasource/getAnalytics.go
+++ b/pkg/datasource/getAnalytics.go
@@ -369,6 +369,7 @@ func (dataProcessor *DataProcessor) processSingleTrace(summary xraytypes.TraceSu
 					}
 				}
 			case QueryGetAnalyticsRootCauseFaultMessage:
+				key = getFaultMessage(cause)
 			default:
 				key = getFaultMessage(cause)
 			}

--- a/src/components/QueryEditor/QueryHeader.tsx
+++ b/src/components/QueryEditor/QueryHeader.tsx
@@ -4,7 +4,6 @@ import { EditorHeader, InlineSelect } from '@grafana/plugin-ui';
 import { XrayDataSource } from '../../XRayDataSource';
 import { XrayQuery, QueryMode, XrayJsonData, Region } from '../../types';
 import React from 'react';
-import { config } from '@grafana/runtime';
 
 export interface Props extends QueryEditorProps<XrayDataSource, XrayQuery, XrayJsonData> {
   regions: Region[];


### PR DESCRIPTION
This migrates the plugin CI/CD processes to Github actions according to [this migration guide](https://enghub.grafana-ops.net/docs/default/component/grafana-plugins-platform/plugins-ci-github-actions/020-migrating-form-drone/)

Right now the shared workflows don't have a mechanism to specify custom Vault secrets in e2e tests, so I had to disable the shared e2e workflow and keep our old e2e action. This might change in the future, but with drone sunset coming up, we don't really have a choice. More info [in this thread ](https://raintank-corp.slack.com/archives/C01C4K8DETW/p1750077883269419?thread_ts=1750072014.548489&cid=C01C4K8DETW)