### PR TITLE
Add app signals services dashboard

### DIFF
--- a/pkg/datasource/getAccounts.go
+++ b/pkg/datasource/getAccounts.go
@@ -66,7 +66,7 @@ func (ds *Datasource) GetAccounts(rw http.ResponseWriter, req *http.Request) {
 			break
 		}
 		for _, service := range page.Services {
-			if service.AccountId != nil {
+			if service.AccountId != nil && *service.AccountId != "all" {
 				account := Account{
 					Id: *service.AccountId,
 				}

--- a/pkg/datasource/getOperations.go
+++ b/pkg/datasource/getOperations.go
@@ -30,6 +30,9 @@ func (ds *Datasource) GetOperations(rw http.ResponseWriter, req *http.Request) {
 	region := urlQuery.Get("region")
 
 	keyAttributes := map[string]string{}
+	if req.Body == nil {
+		return
+	}
 	b, err := io.ReadAll(req.Body)
 	if err != nil {
 		return

--- a/pkg/datasource/getServiceMap.go
+++ b/pkg/datasource/getServiceMap.go
@@ -61,7 +61,7 @@ func (ds *Datasource) getSingleServiceMap(ctx context.Context, query backend.Dat
 			// filter out non matching account ids, if user has selected them
 			if len(queryData.AccountIds) > 0 {
 				// sometimes traces don't have accountId data, without knowing where it came from we have to filter it out
-				if service.AccountId == nil {
+				if service.AccountId == nil || *service.AccountId == "all" {
 					continue
 				}
 

--- a/pkg/datasource/getServices.go
+++ b/pkg/datasource/getServices.go
@@ -55,7 +55,7 @@ func (ds *Datasource) GetServices(rw http.ResponseWriter, req *http.Request) {
 		EndTime:               &endTime,
 		IncludeLinkedAccounts: true,
 	}
-	if len(accountId) > 0 {
+	if accountId != "" && accountId != "all" {
 		input.AwsAccountId = &accountId
 	}
 

--- a/pkg/datasource/listServiceLevelObjectives.go
+++ b/pkg/datasource/listServiceLevelObjectives.go
@@ -52,7 +52,10 @@ func (ds *Datasource) ListServiceLevelObjectives(ctx context.Context, query back
 	}
 
 	if input.IncludeLinkedAccounts {
-		input.KeyAttributes["AwsAccountId"] = queryData.AccountId
+		// only replace the value if accountId is set on the query
+		if queryData.AccountId != "" && queryData.AccountId != "all" {
+			input.KeyAttributes["AwsAccountId"] = queryData.AccountId
+		}
 	} else {
 		if input.KeyAttributes["AwsAccountId"] != "" {
 			// only include accountId attribute of the service if IncludeLinkedAccounts is true

--- a/pkg/datasource/listServices.go
+++ b/pkg/datasource/listServices.go
@@ -55,7 +55,7 @@ func (ds *Datasource) ListServices(ctx context.Context, query backend.DataQuery,
 		EndTime:               &query.TimeRange.To,
 		IncludeLinkedAccounts: queryData.IncludeLinkedAccounts,
 	}
-	if len(queryData.AccountId) > 0 {
+	if queryData.AccountId != "" && queryData.AccountId != "all" {
 		input.AwsAccountId = &queryData.AccountId
 	}
 

--- a/src/dashboards/xray-app-signals.json
+++ b/src/dashboards/xray-app-signals.json
@@ -74,7 +74,7 @@
           "showLineNumbers": false,
           "showMiniMap": false
         },
-        "content": "This dashboard helps visualize Application Signals information from AWS.\nFor more information about Application Signals and how to enable it, see the [AWS Application Signals docs](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CloudWatch-Application-Monitoring-Sections.html).\n\nTo get started with this dashboard, select the appropriate Application Signals data source, CloudWatch data source, and region in the variables above. You can use the account dropdown to further narrow down the list of services.\n\nUse the hyperlinks in the `List Services` panel to update the board with the Service you are examining, and you can use the links in the collapsed boards below to examine an Operation or Dependency of that service.",
+        "content": "This dashboard helps visualize Application Signals information from AWS.\nFor more information about Application Signals and how to enable it, see the [AWS Application Signals docs](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CloudWatch-Application-Monitoring-Sections.html).\n\nTo get started with this dashboard, select the appropriate `appSignalsDatasource`, `cloudwatchDatasource`, and `region` in the variables above. You can use the `account` dropdown to further narrow down the list of services.\n\nUse the hyperlinks in the `List Services` panel to update the board with the Service you are examining, and you can use the links in the collapsed boards below to examine an Operation or Dependency of that service.",
         "mode": "markdown"
       },
       "pluginVersion": "12.1.0-pre",

--- a/src/dashboards/xray-app-signals.json
+++ b/src/dashboards/xray-app-signals.json
@@ -62,7 +62,7 @@
   "panels": [
     {
       "gridPos": {
-        "h": 5,
+        "h": 6,
         "w": 24,
         "x": 0,
         "y": 0
@@ -74,7 +74,7 @@
           "showLineNumbers": false,
           "showMiniMap": false
         },
-        "content": "This dashboard helps visualize Application Signals information from AWS.\nTo get started, select the appropriate X-Ray data source, CloudWatch data source, and region in the variables above. You can use the account dropdown to further narrow down the list of services.\n\nUse the hyperlinks in the `List Services` panel to update the board with the Service you are examining, and you can use the links in the collapsed boards below to examine an Operation or Dependency of that service.",
+        "content": "This dashboard helps visualize Application Signals information from AWS.\nFor more information about Application Signals and how to enable it, see the [AWS Application Signals docs](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CloudWatch-Application-Monitoring-Sections.html).\n\nTo get started with this dashboard, select the appropriate Application Signals data source, CloudWatch data source, and region in the variables above. You can use the account dropdown to further narrow down the list of services.\n\nUse the hyperlinks in the `List Services` panel to update the board with the Service you are examining, and you can use the links in the collapsed boards below to examine an Operation or Dependency of that service.",
         "mode": "markdown"
       },
       "pluginVersion": "12.1.0-pre",
@@ -87,7 +87,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 5
+        "y": 6
       },
       "id": 15,
       "panels": [],
@@ -97,7 +97,7 @@
     {
       "datasource": {
         "type": "grafana-x-ray-datasource",
-        "uid": "${xrayDatasource}"
+        "uid": "${appSignalsDatasource}"
       },
       "fieldConfig": {
         "defaults": {
@@ -138,7 +138,7 @@
         "h": 8,
         "w": 24,
         "x": 0,
-        "y": 6
+        "y": 7
       },
       "id": 2,
       "options": {
@@ -157,7 +157,7 @@
           "accountId": "$account",
           "datasource": {
             "type": "grafana-x-ray-datasource",
-            "uid": "${xrayDatasource}"
+            "uid": "${appSignalsDatasource}"
           },
           "group": {
             "GroupARN": "default",
@@ -241,7 +241,7 @@
         "h": 8,
         "w": 8,
         "x": 0,
-        "y": 14
+        "y": 15
       },
       "id": 5,
       "options": {
@@ -355,7 +355,7 @@
         "h": 8,
         "w": 8,
         "x": 8,
-        "y": 14
+        "y": 15
       },
       "id": 23,
       "options": {
@@ -469,7 +469,7 @@
         "h": 8,
         "w": 8,
         "x": 16,
-        "y": 14
+        "y": 15
       },
       "id": 24,
       "options": {
@@ -583,7 +583,7 @@
         "h": 8,
         "w": 8,
         "x": 0,
-        "y": 22
+        "y": 23
       },
       "id": 19,
       "options": {
@@ -699,7 +699,7 @@
         "h": 8,
         "w": 8,
         "x": 8,
-        "y": 22
+        "y": 23
       },
       "id": 27,
       "options": {
@@ -815,7 +815,7 @@
         "h": 8,
         "w": 8,
         "x": 16,
-        "y": 22
+        "y": 23
       },
       "id": 28,
       "options": {
@@ -868,997 +868,998 @@
       "type": "timeseries"
     },
     {
-      "collapsed": false,
+      "collapsed": true,
       "gridPos": {
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 30
+        "y": 31
       },
       "id": 14,
-      "panels": [],
-      "title": "${service:text} Operations",
-      "type": "row"
-    },
-    {
-      "datasource": {
-        "type": "grafana-x-ray-datasource",
-        "uid": "${xrayDatasource}"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "thresholds"
+      "panels": [
+        {
+          "datasource": {
+            "type": "grafana-x-ray-datasource",
+            "uid": "${appSignalsDatasource}"
           },
-          "custom": {
-            "align": "auto",
-            "cellOptions": {
-              "type": "auto"
-            },
-            "inspect": false
-          },
-          "links": [
-            {
-              "title": "Use dimensions",
-              "url": "/d/4a42f43f-6e29-41df-8037-3f3bb504e05f?var-operationDimensions=${__data.fields.Dimensions}&var-operation=${__data.fields.Name}"
-            }
-          ],
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": 0
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
               },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          }
-        },
-        "overrides": [
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "Dimensions"
-            },
-            "properties": [
-              {
-                "id": "links",
-                "value": [
+              "custom": {
+                "align": "auto",
+                "cellOptions": {
+                  "type": "auto"
+                },
+                "inspect": false
+              },
+              "links": [
+                {
+                  "title": "Use dimensions",
+                  "url": "/d/4a42f43f-6e29-41df-8037-3f3bb504e05f?var-operationDimensions=${__data.fields.Dimensions}&var-operation=${__data.fields.Name}"
+                }
+              ],
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
                   {
-                    "title": "Set new operation",
-                    "url": "/d/4a42f43f-6e29-41df-8037-3f3bb504e05f/xray-app-signals?var-operationDimensions=${__value}"
+                    "color": "green",
+                    "value": 0
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
                   }
                 ]
               }
+            },
+            "overrides": [
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Dimensions"
+                },
+                "properties": [
+                  {
+                    "id": "links",
+                    "value": [
+                      {
+                        "title": "Set new operation",
+                        "url": "/d/4a42f43f-6e29-41df-8037-3f3bb504e05f/xray-app-signals?var-operationDimensions=${__value}"
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": ""
+                },
+                "properties": []
+              }
             ]
           },
-          {
-            "matcher": {
-              "id": "byName",
-              "options": ""
+          "gridPos": {
+            "h": 7,
+            "w": 12,
+            "x": 0,
+            "y": 32
+          },
+          "id": 1,
+          "options": {
+            "cellHeight": "sm",
+            "footer": {
+              "countRows": false,
+              "fields": "",
+              "reducer": ["sum"],
+              "show": false
             },
-            "properties": []
-          }
-        ]
-      },
-      "gridPos": {
-        "h": 7,
-        "w": 12,
-        "x": 0,
-        "y": 31
-      },
-      "id": 1,
-      "options": {
-        "cellHeight": "sm",
-        "footer": {
-          "countRows": false,
-          "fields": "",
-          "reducer": ["sum"],
-          "show": false
+            "showHeader": true,
+            "sortBy": []
+          },
+          "pluginVersion": "12.1.0-pre",
+          "targets": [
+            {
+              "datasource": {
+                "type": "grafana-x-ray-datasource",
+                "uid": "${appSignalsDatasource}"
+              },
+              "group": {
+                "GroupARN": "default",
+                "GroupName": "Default",
+                "InsightsConfiguration": {
+                  "InsightsEnabled": true,
+                  "NotificationsEnabled": true
+                }
+              },
+              "includeLinkedAccounts": true,
+              "query": "",
+              "queryMode": "Services",
+              "queryType": "getTraceSummaries",
+              "refId": "A",
+              "region": "$region",
+              "serviceName": "$service",
+              "serviceQueryType": "listServiceOperations",
+              "serviceString": "$service"
+            }
+          ],
+          "title": "${service:text} Operations",
+          "type": "table"
         },
-        "showHeader": true,
-        "sortBy": []
-      },
-      "pluginVersion": "12.1.0-pre",
-      "targets": [
         {
           "datasource": {
             "type": "grafana-x-ray-datasource",
-            "uid": "${xrayDatasource}"
+            "uid": "${appSignalsDatasource}"
           },
-          "group": {
-            "GroupARN": "default",
-            "GroupName": "Default",
-            "InsightsConfiguration": {
-              "InsightsEnabled": true,
-              "NotificationsEnabled": true
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "custom": {
+                "align": "auto",
+                "cellOptions": {
+                  "type": "auto"
+                },
+                "inspect": false
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": 0
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 7,
+            "w": 12,
+            "x": 12,
+            "y": 32
+          },
+          "id": 3,
+          "options": {
+            "cellHeight": "sm",
+            "footer": {
+              "countRows": false,
+              "fields": "",
+              "reducer": ["sum"],
+              "show": false
+            },
+            "showHeader": true
+          },
+          "pluginVersion": "12.1.0-pre",
+          "targets": [
+            {
+              "accountId": "$account",
+              "datasource": {
+                "type": "grafana-x-ray-datasource",
+                "uid": "${appSignalsDatasource}"
+              },
+              "group": {
+                "GroupARN": "default",
+                "GroupName": "Default",
+                "InsightsConfiguration": {
+                  "InsightsEnabled": true,
+                  "NotificationsEnabled": true
+                }
+              },
+              "includeLinkedAccounts": true,
+              "operationName": "$operation",
+              "query": "",
+              "queryMode": "Services",
+              "queryType": "getTraceSummaries",
+              "refId": "A",
+              "region": "$region",
+              "serviceName": "$service",
+              "serviceQueryType": "listServiceLevelObjectives",
+              "serviceString": "$service"
+            }
+          ],
+          "title": "${service:text} $operation SLOS",
+          "type": "table"
+        },
+        {
+          "datasource": {
+            "type": "cloudwatch",
+            "uid": "${cloudwatchDatasource}"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisBorderShow": false,
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "barWidthFactor": 0.6,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": 0
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 8,
+            "x": 0,
+            "y": 39
+          },
+          "id": 8,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "hideZeros": false,
+              "mode": "single",
+              "sort": "none"
             }
           },
-          "includeLinkedAccounts": true,
-          "query": "",
-          "queryMode": "Services",
-          "queryType": "getTraceSummaries",
-          "refId": "A",
-          "region": "$region",
-          "serviceName": "$service",
-          "serviceQueryType": "listServiceOperations",
-          "serviceString": "$service"
+          "pluginVersion": "12.1.0-pre",
+          "targets": [
+            {
+              "accountId": "$account",
+              "datasource": {
+                "type": "cloudwatch",
+                "uid": "${cloudwatchDatasource}"
+              },
+              "dimensions": {
+                "Environment": "$environment",
+                "Operation": "$operation",
+                "Service": "${service:text}"
+              },
+              "expression": "",
+              "id": "",
+              "label": "",
+              "logGroups": [],
+              "matchExact": true,
+              "metricEditorMode": 0,
+              "metricName": "Latency",
+              "metricQueryType": 0,
+              "namespace": "ApplicationSignals",
+              "period": "",
+              "queryLanguage": "CWLI",
+              "queryMode": "Metrics",
+              "refId": "A",
+              "region": "$region",
+              "sqlExpression": "",
+              "statistic": "Average"
+            }
+          ],
+          "title": "${operation} Latency",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "cloudwatch",
+            "uid": "${cloudwatchDatasource}"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisBorderShow": false,
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "barWidthFactor": 0.6,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": 0
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 8,
+            "x": 8,
+            "y": 39
+          },
+          "id": 25,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "hideZeros": false,
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "pluginVersion": "12.1.0-pre",
+          "targets": [
+            {
+              "accountId": "$account",
+              "datasource": {
+                "type": "cloudwatch",
+                "uid": "${cloudwatchDatasource}"
+              },
+              "dimensions": {
+                "Environment": "$environment",
+                "Operation": "$operation",
+                "Service": "${service:text}"
+              },
+              "expression": "",
+              "id": "",
+              "label": "",
+              "logGroups": [],
+              "matchExact": true,
+              "metricEditorMode": 0,
+              "metricName": "Error",
+              "metricQueryType": 0,
+              "namespace": "ApplicationSignals",
+              "period": "",
+              "queryLanguage": "CWLI",
+              "queryMode": "Metrics",
+              "refId": "A",
+              "region": "$region",
+              "sqlExpression": "",
+              "statistic": "Average"
+            }
+          ],
+          "title": "${operation} Error",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "cloudwatch",
+            "uid": "${cloudwatchDatasource}"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisBorderShow": false,
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "barWidthFactor": 0.6,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": 0
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 8,
+            "x": 16,
+            "y": 39
+          },
+          "id": 26,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "hideZeros": false,
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "pluginVersion": "12.1.0-pre",
+          "targets": [
+            {
+              "accountId": "$account",
+              "datasource": {
+                "type": "cloudwatch",
+                "uid": "${cloudwatchDatasource}"
+              },
+              "dimensions": {
+                "Environment": "$environment",
+                "Operation": "$operation",
+                "Service": "${service:text}"
+              },
+              "expression": "",
+              "id": "",
+              "label": "",
+              "logGroups": [],
+              "matchExact": true,
+              "metricEditorMode": 0,
+              "metricName": "Fault",
+              "metricQueryType": 0,
+              "namespace": "ApplicationSignals",
+              "period": "",
+              "queryLanguage": "CWLI",
+              "queryMode": "Metrics",
+              "refId": "A",
+              "region": "$region",
+              "sqlExpression": "",
+              "statistic": "Average"
+            }
+          ],
+          "title": "${operation} Fault",
+          "type": "timeseries"
         }
       ],
       "title": "${service:text} Operations",
-      "type": "table"
+      "type": "row"
     },
     {
-      "datasource": {
-        "type": "grafana-x-ray-datasource",
-        "uid": "${xrayDatasource}"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "thresholds"
-          },
-          "custom": {
-            "align": "auto",
-            "cellOptions": {
-              "type": "auto"
-            },
-            "inspect": false
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": 0
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          }
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 7,
-        "w": 12,
-        "x": 12,
-        "y": 31
-      },
-      "id": 3,
-      "options": {
-        "cellHeight": "sm",
-        "footer": {
-          "countRows": false,
-          "fields": "",
-          "reducer": ["sum"],
-          "show": false
-        },
-        "showHeader": true
-      },
-      "pluginVersion": "12.1.0-pre",
-      "targets": [
-        {
-          "accountId": "$account",
-          "datasource": {
-            "type": "grafana-x-ray-datasource",
-            "uid": "${xrayDatasource}"
-          },
-          "group": {
-            "GroupARN": "default",
-            "GroupName": "Default",
-            "InsightsConfiguration": {
-              "InsightsEnabled": true,
-              "NotificationsEnabled": true
-            }
-          },
-          "includeLinkedAccounts": true,
-          "operationName": "$operation",
-          "query": "",
-          "queryMode": "Services",
-          "queryType": "getTraceSummaries",
-          "refId": "A",
-          "region": "$region",
-          "serviceName": "$service",
-          "serviceQueryType": "listServiceLevelObjectives",
-          "serviceString": "$service"
-        }
-      ],
-      "title": "${service:text} $operation SLOS",
-      "type": "table"
-    },
-    {
-      "datasource": {
-        "type": "cloudwatch",
-        "uid": "${cloudwatchDatasource}"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "axisBorderShow": false,
-            "axisCenteredZero": false,
-            "axisColorMode": "text",
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "barWidthFactor": 0.6,
-            "drawStyle": "line",
-            "fillOpacity": 0,
-            "gradientMode": "none",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "insertNulls": false,
-            "lineInterpolation": "linear",
-            "lineWidth": 1,
-            "pointSize": 5,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "showPoints": "auto",
-            "spanNulls": false,
-            "stacking": {
-              "group": "A",
-              "mode": "none"
-            },
-            "thresholdsStyle": {
-              "mode": "off"
-            }
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": 0
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          }
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 8,
-        "x": 0,
-        "y": 38
-      },
-      "id": 8,
-      "options": {
-        "legend": {
-          "calcs": [],
-          "displayMode": "list",
-          "placement": "bottom",
-          "showLegend": true
-        },
-        "tooltip": {
-          "hideZeros": false,
-          "mode": "single",
-          "sort": "none"
-        }
-      },
-      "pluginVersion": "12.1.0-pre",
-      "targets": [
-        {
-          "accountId": "$account",
-          "datasource": {
-            "type": "cloudwatch",
-            "uid": "${cloudwatchDatasource}"
-          },
-          "dimensions": {
-            "Environment": "$environment",
-            "Operation": "$operation",
-            "Service": "${service:text}"
-          },
-          "expression": "",
-          "id": "",
-          "label": "",
-          "logGroups": [],
-          "matchExact": true,
-          "metricEditorMode": 0,
-          "metricName": "Latency",
-          "metricQueryType": 0,
-          "namespace": "ApplicationSignals",
-          "period": "",
-          "queryLanguage": "CWLI",
-          "queryMode": "Metrics",
-          "refId": "A",
-          "region": "$region",
-          "sqlExpression": "",
-          "statistic": "Average"
-        }
-      ],
-      "title": "${operation} Latency",
-      "type": "timeseries"
-    },
-    {
-      "datasource": {
-        "type": "cloudwatch",
-        "uid": "${cloudwatchDatasource}"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "axisBorderShow": false,
-            "axisCenteredZero": false,
-            "axisColorMode": "text",
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "barWidthFactor": 0.6,
-            "drawStyle": "line",
-            "fillOpacity": 0,
-            "gradientMode": "none",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "insertNulls": false,
-            "lineInterpolation": "linear",
-            "lineWidth": 1,
-            "pointSize": 5,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "showPoints": "auto",
-            "spanNulls": false,
-            "stacking": {
-              "group": "A",
-              "mode": "none"
-            },
-            "thresholdsStyle": {
-              "mode": "off"
-            }
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": 0
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          }
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 8,
-        "x": 8,
-        "y": 38
-      },
-      "id": 25,
-      "options": {
-        "legend": {
-          "calcs": [],
-          "displayMode": "list",
-          "placement": "bottom",
-          "showLegend": true
-        },
-        "tooltip": {
-          "hideZeros": false,
-          "mode": "single",
-          "sort": "none"
-        }
-      },
-      "pluginVersion": "12.1.0-pre",
-      "targets": [
-        {
-          "accountId": "$account",
-          "datasource": {
-            "type": "cloudwatch",
-            "uid": "${cloudwatchDatasource}"
-          },
-          "dimensions": {
-            "Environment": "$environment",
-            "Operation": "$operation",
-            "Service": "${service:text}"
-          },
-          "expression": "",
-          "id": "",
-          "label": "",
-          "logGroups": [],
-          "matchExact": true,
-          "metricEditorMode": 0,
-          "metricName": "Error",
-          "metricQueryType": 0,
-          "namespace": "ApplicationSignals",
-          "period": "",
-          "queryLanguage": "CWLI",
-          "queryMode": "Metrics",
-          "refId": "A",
-          "region": "$region",
-          "sqlExpression": "",
-          "statistic": "Average"
-        }
-      ],
-      "title": "${operation} Error",
-      "type": "timeseries"
-    },
-    {
-      "datasource": {
-        "type": "cloudwatch",
-        "uid": "${cloudwatchDatasource}"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "axisBorderShow": false,
-            "axisCenteredZero": false,
-            "axisColorMode": "text",
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "barWidthFactor": 0.6,
-            "drawStyle": "line",
-            "fillOpacity": 0,
-            "gradientMode": "none",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "insertNulls": false,
-            "lineInterpolation": "linear",
-            "lineWidth": 1,
-            "pointSize": 5,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "showPoints": "auto",
-            "spanNulls": false,
-            "stacking": {
-              "group": "A",
-              "mode": "none"
-            },
-            "thresholdsStyle": {
-              "mode": "off"
-            }
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": 0
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          }
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 8,
-        "x": 16,
-        "y": 38
-      },
-      "id": 26,
-      "options": {
-        "legend": {
-          "calcs": [],
-          "displayMode": "list",
-          "placement": "bottom",
-          "showLegend": true
-        },
-        "tooltip": {
-          "hideZeros": false,
-          "mode": "single",
-          "sort": "none"
-        }
-      },
-      "pluginVersion": "12.1.0-pre",
-      "targets": [
-        {
-          "accountId": "$account",
-          "datasource": {
-            "type": "cloudwatch",
-            "uid": "${cloudwatchDatasource}"
-          },
-          "dimensions": {
-            "Environment": "$environment",
-            "Operation": "$operation",
-            "Service": "${service:text}"
-          },
-          "expression": "",
-          "id": "",
-          "label": "",
-          "logGroups": [],
-          "matchExact": true,
-          "metricEditorMode": 0,
-          "metricName": "Fault",
-          "metricQueryType": 0,
-          "namespace": "ApplicationSignals",
-          "period": "",
-          "queryLanguage": "CWLI",
-          "queryMode": "Metrics",
-          "refId": "A",
-          "region": "$region",
-          "sqlExpression": "",
-          "statistic": "Average"
-        }
-      ],
-      "title": "${operation} Fault",
-      "type": "timeseries"
-    },
-    {
-      "collapsed": false,
+      "collapsed": true,
       "gridPos": {
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 46
+        "y": 32
       },
       "id": 16,
-      "panels": [],
-      "title": "${service:text} Dependencies",
-      "type": "row"
-    },
-    {
-      "datasource": {
-        "type": "grafana-x-ray-datasource",
-        "uid": "${xrayDatasource}"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "thresholds"
-          },
-          "custom": {
-            "align": "auto",
-            "cellOptions": {
-              "type": "auto"
-            },
-            "inspect": false
-          },
-          "links": [
-            {
-              "title": "Use dependency",
-              "url": "/d/4a42f43f-6e29-41df-8037-3f3bb504e05f?var-dependencyDimensions=${__data.fields.Dimensions}﻿﻿&var-dependency=﻿${__data.fields.DependencyOperationName}"
-            }
-          ],
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": 0
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          }
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 7,
-        "w": 24,
-        "x": 0,
-        "y": 47
-      },
-      "id": 4,
-      "options": {
-        "cellHeight": "sm",
-        "footer": {
-          "countRows": false,
-          "fields": "",
-          "reducer": ["sum"],
-          "show": false
-        },
-        "showHeader": true,
-        "sortBy": [
-          {
-            "desc": false,
-            "displayName": "DependencyOperationName"
-          }
-        ]
-      },
-      "pluginVersion": "12.1.0-pre",
-      "targets": [
+      "panels": [
         {
           "datasource": {
             "type": "grafana-x-ray-datasource",
-            "uid": "${xrayDatasource}"
+            "uid": "${appSignalsDatasource}"
           },
-          "group": {
-            "GroupARN": "default",
-            "GroupName": "Default",
-            "InsightsConfiguration": {
-              "InsightsEnabled": true,
-              "NotificationsEnabled": true
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "custom": {
+                "align": "auto",
+                "cellOptions": {
+                  "type": "auto"
+                },
+                "inspect": false
+              },
+              "links": [
+                {
+                  "title": "Use dependency",
+                  "url": "/d/4a42f43f-6e29-41df-8037-3f3bb504e05f?var-dependencyDimensions=${__data.fields.Dimensions}﻿﻿&var-dependency=﻿${__data.fields.DependencyOperationName}"
+                }
+              ],
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": 0
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 7,
+            "w": 24,
+            "x": 0,
+            "y": 33
+          },
+          "id": 4,
+          "options": {
+            "cellHeight": "sm",
+            "footer": {
+              "countRows": false,
+              "fields": "",
+              "reducer": ["sum"],
+              "show": false
+            },
+            "showHeader": true,
+            "sortBy": [
+              {
+                "desc": false,
+                "displayName": "DependencyOperationName"
+              }
+            ]
+          },
+          "pluginVersion": "12.1.0-pre",
+          "targets": [
+            {
+              "datasource": {
+                "type": "grafana-x-ray-datasource",
+                "uid": "${appSignalsDatasource}"
+              },
+              "group": {
+                "GroupARN": "default",
+                "GroupName": "Default",
+                "InsightsConfiguration": {
+                  "InsightsEnabled": true,
+                  "NotificationsEnabled": true
+                }
+              },
+              "query": "",
+              "queryMode": "Services",
+              "queryType": "getTraceSummaries",
+              "refId": "A",
+              "region": "$region",
+              "serviceName": "$service",
+              "serviceQueryType": "listServiceDependencies",
+              "serviceString": "$service"
+            }
+          ],
+          "title": "${service:text} Dependencies",
+          "type": "table"
+        },
+        {
+          "datasource": {
+            "type": "cloudwatch",
+            "uid": "${cloudwatchDatasource}"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisBorderShow": false,
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "barWidthFactor": 0.6,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": 0
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 8,
+            "x": 0,
+            "y": 40
+          },
+          "id": 11,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "hideZeros": false,
+              "mode": "single",
+              "sort": "none"
             }
           },
-          "query": "",
-          "queryMode": "Services",
-          "queryType": "getTraceSummaries",
-          "refId": "A",
-          "region": "$region",
-          "serviceName": "$service",
-          "serviceQueryType": "listServiceDependencies",
-          "serviceString": "$service"
+          "pluginVersion": "12.1.0-pre",
+          "targets": [
+            {
+              "accountId": "$account",
+              "datasource": {
+                "type": "cloudwatch",
+                "uid": "${cloudwatchDatasource}"
+              },
+              "dimensions": {},
+              "expression": "REMOVE_EMPTY(SEARCH('Namespace=\"ApplicationSignals\" MetricName=\"Latency\" $dependencyDimensions', 'Average', 60))",
+              "id": "",
+              "label": "",
+              "logGroups": [],
+              "matchExact": true,
+              "metricEditorMode": 1,
+              "metricName": "Latency",
+              "metricQueryType": 0,
+              "namespace": "ApplicationSignals",
+              "period": "",
+              "queryLanguage": "CWLI",
+              "queryMode": "Metrics",
+              "refId": "A",
+              "region": "$region",
+              "sqlExpression": "",
+              "statistic": "Average"
+            }
+          ],
+          "title": "${dependency} Latency",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "cloudwatch",
+            "uid": "${cloudwatchDatasource}"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisBorderShow": false,
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "barWidthFactor": 0.6,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": 0
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 8,
+            "x": 8,
+            "y": 40
+          },
+          "id": 29,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "hideZeros": false,
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "pluginVersion": "12.1.0-pre",
+          "targets": [
+            {
+              "accountId": "$account",
+              "datasource": {
+                "type": "cloudwatch",
+                "uid": "${cloudwatchDatasource}"
+              },
+              "dimensions": {},
+              "expression": "REMOVE_EMPTY(SEARCH('Namespace=\"ApplicationSignals\" MetricName=\"Error\" $dependencyDimensions', 'Average', 60))",
+              "id": "",
+              "label": "",
+              "logGroups": [],
+              "matchExact": true,
+              "metricEditorMode": 1,
+              "metricName": "Latency",
+              "metricQueryType": 0,
+              "namespace": "ApplicationSignals",
+              "period": "",
+              "queryLanguage": "CWLI",
+              "queryMode": "Metrics",
+              "refId": "A",
+              "region": "$region",
+              "sqlExpression": "",
+              "statistic": "Average"
+            }
+          ],
+          "title": "${dependency} Error",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "cloudwatch",
+            "uid": "${cloudwatchDatasource}"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisBorderShow": false,
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "barWidthFactor": 0.6,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": 0
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 8,
+            "x": 16,
+            "y": 40
+          },
+          "id": 30,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "hideZeros": false,
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "pluginVersion": "12.1.0-pre",
+          "targets": [
+            {
+              "accountId": "$account",
+              "datasource": {
+                "type": "cloudwatch",
+                "uid": "${cloudwatchDatasource}"
+              },
+              "dimensions": {},
+              "expression": "REMOVE_EMPTY(SEARCH('Namespace=\"ApplicationSignals\" MetricName=\"Fault\" $dependencyDimensions', 'Average', 60))",
+              "id": "",
+              "label": "",
+              "logGroups": [],
+              "matchExact": true,
+              "metricEditorMode": 1,
+              "metricName": "Latency",
+              "metricQueryType": 0,
+              "namespace": "ApplicationSignals",
+              "period": "",
+              "queryLanguage": "CWLI",
+              "queryMode": "Metrics",
+              "refId": "A",
+              "region": "$region",
+              "sqlExpression": "",
+              "statistic": "Average"
+            }
+          ],
+          "title": "${dependency} Fault",
+          "type": "timeseries"
         }
       ],
       "title": "${service:text} Dependencies",
-      "type": "table"
-    },
-    {
-      "datasource": {
-        "type": "cloudwatch",
-        "uid": "${cloudwatchDatasource}"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "axisBorderShow": false,
-            "axisCenteredZero": false,
-            "axisColorMode": "text",
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "barWidthFactor": 0.6,
-            "drawStyle": "line",
-            "fillOpacity": 0,
-            "gradientMode": "none",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "insertNulls": false,
-            "lineInterpolation": "linear",
-            "lineWidth": 1,
-            "pointSize": 5,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "showPoints": "auto",
-            "spanNulls": false,
-            "stacking": {
-              "group": "A",
-              "mode": "none"
-            },
-            "thresholdsStyle": {
-              "mode": "off"
-            }
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": 0
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          }
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 8,
-        "x": 0,
-        "y": 54
-      },
-      "id": 11,
-      "options": {
-        "legend": {
-          "calcs": [],
-          "displayMode": "list",
-          "placement": "bottom",
-          "showLegend": true
-        },
-        "tooltip": {
-          "hideZeros": false,
-          "mode": "single",
-          "sort": "none"
-        }
-      },
-      "pluginVersion": "12.1.0-pre",
-      "targets": [
-        {
-          "accountId": "$account",
-          "datasource": {
-            "type": "cloudwatch",
-            "uid": "${cloudwatchDatasource}"
-          },
-          "dimensions": {},
-          "expression": "REMOVE_EMPTY(SEARCH('Namespace=\"ApplicationSignals\" MetricName=\"Latency\" $dependencyDimensions', 'Average', 60))",
-          "id": "",
-          "label": "",
-          "logGroups": [],
-          "matchExact": true,
-          "metricEditorMode": 1,
-          "metricName": "Latency",
-          "metricQueryType": 0,
-          "namespace": "ApplicationSignals",
-          "period": "",
-          "queryLanguage": "CWLI",
-          "queryMode": "Metrics",
-          "refId": "A",
-          "region": "$region",
-          "sqlExpression": "",
-          "statistic": "Average"
-        }
-      ],
-      "title": "${dependency} Latency",
-      "type": "timeseries"
-    },
-    {
-      "datasource": {
-        "type": "cloudwatch",
-        "uid": "${cloudwatchDatasource}"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "axisBorderShow": false,
-            "axisCenteredZero": false,
-            "axisColorMode": "text",
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "barWidthFactor": 0.6,
-            "drawStyle": "line",
-            "fillOpacity": 0,
-            "gradientMode": "none",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "insertNulls": false,
-            "lineInterpolation": "linear",
-            "lineWidth": 1,
-            "pointSize": 5,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "showPoints": "auto",
-            "spanNulls": false,
-            "stacking": {
-              "group": "A",
-              "mode": "none"
-            },
-            "thresholdsStyle": {
-              "mode": "off"
-            }
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": 0
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          }
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 8,
-        "x": 8,
-        "y": 54
-      },
-      "id": 29,
-      "options": {
-        "legend": {
-          "calcs": [],
-          "displayMode": "list",
-          "placement": "bottom",
-          "showLegend": true
-        },
-        "tooltip": {
-          "hideZeros": false,
-          "mode": "single",
-          "sort": "none"
-        }
-      },
-      "pluginVersion": "12.1.0-pre",
-      "targets": [
-        {
-          "accountId": "$account",
-          "datasource": {
-            "type": "cloudwatch",
-            "uid": "${cloudwatchDatasource}"
-          },
-          "dimensions": {},
-          "expression": "REMOVE_EMPTY(SEARCH('Namespace=\"ApplicationSignals\" MetricName=\"Error\" $dependencyDimensions', 'Average', 60))",
-          "id": "",
-          "label": "",
-          "logGroups": [],
-          "matchExact": true,
-          "metricEditorMode": 1,
-          "metricName": "Latency",
-          "metricQueryType": 0,
-          "namespace": "ApplicationSignals",
-          "period": "",
-          "queryLanguage": "CWLI",
-          "queryMode": "Metrics",
-          "refId": "A",
-          "region": "$region",
-          "sqlExpression": "",
-          "statistic": "Average"
-        }
-      ],
-      "title": "${dependency} Error",
-      "type": "timeseries"
-    },
-    {
-      "datasource": {
-        "type": "cloudwatch",
-        "uid": "${cloudwatchDatasource}"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "axisBorderShow": false,
-            "axisCenteredZero": false,
-            "axisColorMode": "text",
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "barWidthFactor": 0.6,
-            "drawStyle": "line",
-            "fillOpacity": 0,
-            "gradientMode": "none",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "insertNulls": false,
-            "lineInterpolation": "linear",
-            "lineWidth": 1,
-            "pointSize": 5,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "showPoints": "auto",
-            "spanNulls": false,
-            "stacking": {
-              "group": "A",
-              "mode": "none"
-            },
-            "thresholdsStyle": {
-              "mode": "off"
-            }
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": 0
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          }
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 8,
-        "x": 16,
-        "y": 54
-      },
-      "id": 30,
-      "options": {
-        "legend": {
-          "calcs": [],
-          "displayMode": "list",
-          "placement": "bottom",
-          "showLegend": true
-        },
-        "tooltip": {
-          "hideZeros": false,
-          "mode": "single",
-          "sort": "none"
-        }
-      },
-      "pluginVersion": "12.1.0-pre",
-      "targets": [
-        {
-          "accountId": "$account",
-          "datasource": {
-            "type": "cloudwatch",
-            "uid": "${cloudwatchDatasource}"
-          },
-          "dimensions": {},
-          "expression": "REMOVE_EMPTY(SEARCH('Namespace=\"ApplicationSignals\" MetricName=\"Fault\" $dependencyDimensions', 'Average', 60))",
-          "id": "",
-          "label": "",
-          "logGroups": [],
-          "matchExact": true,
-          "metricEditorMode": 1,
-          "metricName": "Latency",
-          "metricQueryType": 0,
-          "namespace": "ApplicationSignals",
-          "period": "",
-          "queryLanguage": "CWLI",
-          "queryMode": "Metrics",
-          "refId": "A",
-          "region": "$region",
-          "sqlExpression": "",
-          "statistic": "Average"
-        }
-      ],
-      "title": "${dependency} Fault",
-      "type": "timeseries"
+      "type": "row"
     }
   ],
-  "preload": false,
   "schemaVersion": 41,
   "tags": [],
   "templating": {
     "list": [
       {
         "current": {},
-        "name": "xrayDatasource",
+        "name": "appSignalsDatasource",
         "options": [],
         "query": "grafana-x-ray-datasource",
         "refresh": 1,
@@ -1878,7 +1879,7 @@
         "current": {},
         "datasource": {
           "type": "grafana-x-ray-datasource",
-          "uid": "${xrayDatasource}"
+          "uid": "${appSignalsDatasource}"
         },
         "definition": "",
         "name": "region",
@@ -1894,7 +1895,7 @@
         "current": {},
         "datasource": {
           "type": "grafana-x-ray-datasource",
-          "uid": "${xrayDatasource}"
+          "uid": "${appSignalsDatasource}"
         },
         "definition": "",
         "name": "account",
@@ -1920,7 +1921,7 @@
         "current": {},
         "datasource": {
           "type": "grafana-x-ray-datasource",
-          "uid": "${xrayDatasource}"
+          "uid": "${appSignalsDatasource}"
         },
         "definition": "",
         "hide": 2,
@@ -1947,7 +1948,7 @@
         "current": {},
         "datasource": {
           "type": "grafana-x-ray-datasource",
-          "uid": "${xrayDatasource}"
+          "uid": "${appSignalsDatasource}"
         },
         "definition": "",
         "hide": 2,
@@ -1998,8 +1999,8 @@
       },
       {
         "current": {
-          "text": "",
-          "value": ""
+          "text": "eks:app-signals-demo/default",
+          "value": "eks:app-signals-demo/default"
         },
         "hide": 2,
         "name": "environment",
@@ -2017,6 +2018,6 @@
   "timezone": "browser",
   "title": "Application Signals: Services",
   "uid": "4a42f43f-6e29-41df-8037-3f3bb504e05f",
-  "version": 20,
+  "version": 21,
   "weekStart": ""
 }

--- a/src/dashboards/xray-app-signals.json
+++ b/src/dashboards/xray-app-signals.json
@@ -1,0 +1,2022 @@
+{
+  "__elements": {},
+  "__requires": [
+    {
+      "type": "datasource",
+      "id": "cloudwatch",
+      "name": "CloudWatch",
+      "version": "1.0.0"
+    },
+    {
+      "type": "grafana",
+      "id": "grafana",
+      "name": "Grafana",
+      "version": "12.1.0-pre"
+    },
+    {
+      "type": "datasource",
+      "id": "grafana-x-ray-datasource",
+      "name": "AWS X-Ray",
+      "version": "2.15.0"
+    },
+    {
+      "type": "panel",
+      "id": "table",
+      "name": "Table",
+      "version": ""
+    },
+    {
+      "type": "panel",
+      "id": "text",
+      "name": "Text",
+      "version": ""
+    },
+    {
+      "type": "panel",
+      "id": "timeseries",
+      "name": "Time series",
+      "version": ""
+    }
+  ],
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "id": null,
+  "links": [],
+  "panels": [
+    {
+      "gridPos": {
+        "h": 5,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 22,
+      "options": {
+        "code": {
+          "language": "plaintext",
+          "showLineNumbers": false,
+          "showMiniMap": false
+        },
+        "content": "This dashboard helps visualize Application Signals information from AWS.\nTo get started, select the appropriate X-Ray data source, CloudWatch data source, and region in the variables above. You can use the account dropdown to further narrow down the list of services.\n\nUse the hyperlinks in the `List Services` panel to update the board with the Service you are examining, and you can use the links in the collapsed boards below to examine an Operation or Dependency of that service.",
+        "mode": "markdown"
+      },
+      "pluginVersion": "12.1.0-pre",
+      "title": "Application Signals Dashboard",
+      "type": "text"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 5
+      },
+      "id": 15,
+      "panels": [],
+      "title": "Services",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "grafana-x-ray-datasource",
+        "uid": "${xrayDatasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "custom": {
+            "align": "auto",
+            "cellOptions": {
+              "type": "auto"
+            },
+            "inspect": false
+          },
+          "links": [
+            {
+              "title": "use service",
+              "url": "/d/4a42f43f-6e29-41df-8037-3f3bb504e05f?var-environment=${__data.fields.Environment}&var-service=${__data.fields.KeyAttributes}&var-serviceKeys=${__data.fields.DimensionKeys}"
+            }
+          ],
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 6
+      },
+      "id": 2,
+      "options": {
+        "cellHeight": "sm",
+        "footer": {
+          "countRows": false,
+          "fields": "",
+          "reducer": ["sum"],
+          "show": false
+        },
+        "showHeader": true
+      },
+      "pluginVersion": "12.1.0-pre",
+      "targets": [
+        {
+          "accountId": "$account",
+          "datasource": {
+            "type": "grafana-x-ray-datasource",
+            "uid": "${xrayDatasource}"
+          },
+          "group": {
+            "GroupARN": "default",
+            "GroupName": "Default"
+          },
+          "includeLinkedAccounts": true,
+          "query": "",
+          "queryMode": "Services",
+          "queryType": "getTraceSummaries",
+          "refId": "A",
+          "region": "$region",
+          "serviceName": "$service",
+          "serviceQueryType": "listServices",
+          "serviceString": "$service"
+        }
+      ],
+      "title": "List Services",
+      "type": "table"
+    },
+    {
+      "datasource": {
+        "type": "cloudwatch",
+        "uid": "${cloudwatchDatasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 0,
+        "y": 14
+      },
+      "id": 5,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "12.1.0-pre",
+      "targets": [
+        {
+          "accountId": "$account",
+          "datasource": {
+            "type": "cloudwatch",
+            "uid": "${cloudwatchDatasource}"
+          },
+          "dimensions": {
+            "Environment": "$environment",
+            "Operation": "*",
+            "Service": "${service:text}"
+          },
+          "expression": "REMOVE_EMPTY(SEARCH('{\"ApplicationSignals\", $serviceKeys,\"Operation\"} MetricName=\"Latency\" $serviceDimensions', 'Average', 60))",
+          "id": "",
+          "label": "${PROP('Dim.Operation')} ",
+          "logGroups": [],
+          "matchExact": true,
+          "metricEditorMode": 0,
+          "metricName": "Latency",
+          "metricQueryType": 0,
+          "namespace": "ApplicationSignals",
+          "period": "",
+          "queryLanguage": "CWLI",
+          "queryMode": "Metrics",
+          "refId": "A",
+          "region": "$region",
+          "sqlExpression": "",
+          "statistic": "Average"
+        }
+      ],
+      "title": "${service:text} Operations Latency",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "cloudwatch",
+        "uid": "${cloudwatchDatasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 8,
+        "y": 14
+      },
+      "id": 23,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "12.1.0-pre",
+      "targets": [
+        {
+          "accountId": "$account",
+          "datasource": {
+            "type": "cloudwatch",
+            "uid": "${cloudwatchDatasource}"
+          },
+          "dimensions": {
+            "Environment": "$environment",
+            "Operation": "*",
+            "Service": "${service:text}"
+          },
+          "expression": "",
+          "id": "",
+          "label": "${PROP('Dim.Operation')} ",
+          "logGroups": [],
+          "matchExact": true,
+          "metricEditorMode": 0,
+          "metricName": "Error",
+          "metricQueryType": 0,
+          "namespace": "ApplicationSignals",
+          "period": "",
+          "queryLanguage": "CWLI",
+          "queryMode": "Metrics",
+          "refId": "A",
+          "region": "$region",
+          "sqlExpression": "",
+          "statistic": "Average"
+        }
+      ],
+      "title": "${service:text} Operations Error",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "cloudwatch",
+        "uid": "${cloudwatchDatasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 16,
+        "y": 14
+      },
+      "id": 24,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "12.1.0-pre",
+      "targets": [
+        {
+          "accountId": "$account",
+          "datasource": {
+            "type": "cloudwatch",
+            "uid": "${cloudwatchDatasource}"
+          },
+          "dimensions": {
+            "Environment": "$environment",
+            "Operation": "*",
+            "Service": "${service:text}"
+          },
+          "expression": "",
+          "id": "",
+          "label": "${PROP('Dim.Operation')} ",
+          "logGroups": [],
+          "matchExact": true,
+          "metricEditorMode": 0,
+          "metricName": "Fault",
+          "metricQueryType": 0,
+          "namespace": "ApplicationSignals",
+          "period": "",
+          "queryLanguage": "CWLI",
+          "queryMode": "Metrics",
+          "refId": "A",
+          "region": "$region",
+          "sqlExpression": "",
+          "statistic": "Average"
+        }
+      ],
+      "title": "${service:text} Operations Fault",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "cloudwatch",
+        "uid": "${cloudwatchDatasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 0,
+        "y": 22
+      },
+      "id": 19,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "12.1.0-pre",
+      "targets": [
+        {
+          "accountId": "$account",
+          "datasource": {
+            "type": "cloudwatch",
+            "uid": "${cloudwatchDatasource}"
+          },
+          "dimensions": {
+            "Environment": "$environment",
+            "Operation": "*",
+            "RemoteOperation": "*",
+            "RemoteService": "*",
+            "Service": "${service:text}"
+          },
+          "expression": "",
+          "id": "",
+          "label": "${PROP('Dim.Operation')} > ${PROP('Dim.RemoteService')} > ${PROP('Dim.RemoteOperation')} ",
+          "logGroups": [],
+          "matchExact": false,
+          "metricEditorMode": 0,
+          "metricName": "Latency",
+          "metricQueryType": 0,
+          "namespace": "ApplicationSignals",
+          "period": "",
+          "queryLanguage": "CWLI",
+          "queryMode": "Metrics",
+          "refId": "A",
+          "region": "$region",
+          "sqlExpression": "",
+          "statistic": "Average"
+        }
+      ],
+      "title": "${service:text} Dependencies Latency",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "cloudwatch",
+        "uid": "${cloudwatchDatasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 8,
+        "y": 22
+      },
+      "id": 27,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "12.1.0-pre",
+      "targets": [
+        {
+          "accountId": "$account",
+          "datasource": {
+            "type": "cloudwatch",
+            "uid": "${cloudwatchDatasource}"
+          },
+          "dimensions": {
+            "Environment": "$environment",
+            "Operation": "*",
+            "RemoteOperation": "*",
+            "RemoteService": "*",
+            "Service": "${service:text}"
+          },
+          "expression": "",
+          "id": "",
+          "label": "",
+          "logGroups": [],
+          "matchExact": false,
+          "metricEditorMode": 0,
+          "metricName": "Error",
+          "metricQueryType": 0,
+          "namespace": "ApplicationSignals",
+          "period": "",
+          "queryLanguage": "CWLI",
+          "queryMode": "Metrics",
+          "refId": "A",
+          "region": "$region",
+          "sqlExpression": "",
+          "statistic": "Average"
+        }
+      ],
+      "title": "${service:text} Dependencies Error",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "cloudwatch",
+        "uid": "${cloudwatchDatasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 16,
+        "y": 22
+      },
+      "id": 28,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "12.1.0-pre",
+      "targets": [
+        {
+          "accountId": "$account",
+          "datasource": {
+            "type": "cloudwatch",
+            "uid": "${cloudwatchDatasource}"
+          },
+          "dimensions": {
+            "Environment": "$environment",
+            "Operation": "*",
+            "RemoteOperation": "*",
+            "RemoteService": "*",
+            "Service": "${service:text}"
+          },
+          "expression": "",
+          "id": "",
+          "label": "",
+          "logGroups": [],
+          "matchExact": false,
+          "metricEditorMode": 0,
+          "metricName": "Fault",
+          "metricQueryType": 0,
+          "namespace": "ApplicationSignals",
+          "period": "",
+          "queryLanguage": "CWLI",
+          "queryMode": "Metrics",
+          "refId": "A",
+          "region": "$region",
+          "sqlExpression": "",
+          "statistic": "Average"
+        }
+      ],
+      "title": "${service:text} Dependencies Fault",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 30
+      },
+      "id": 14,
+      "panels": [],
+      "title": "${service:text} Operations",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "grafana-x-ray-datasource",
+        "uid": "${xrayDatasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "custom": {
+            "align": "auto",
+            "cellOptions": {
+              "type": "auto"
+            },
+            "inspect": false
+          },
+          "links": [
+            {
+              "title": "Use dimensions",
+              "url": "/d/4a42f43f-6e29-41df-8037-3f3bb504e05f?var-operationDimensions=${__data.fields.Dimensions}&var-operation=${__data.fields.Name}"
+            }
+          ],
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Dimensions"
+            },
+            "properties": [
+              {
+                "id": "links",
+                "value": [
+                  {
+                    "title": "Set new operation",
+                    "url": "/d/4a42f43f-6e29-41df-8037-3f3bb504e05f/xray-app-signals?var-operationDimensions=${__value}"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": ""
+            },
+            "properties": []
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 12,
+        "x": 0,
+        "y": 31
+      },
+      "id": 1,
+      "options": {
+        "cellHeight": "sm",
+        "footer": {
+          "countRows": false,
+          "fields": "",
+          "reducer": ["sum"],
+          "show": false
+        },
+        "showHeader": true,
+        "sortBy": []
+      },
+      "pluginVersion": "12.1.0-pre",
+      "targets": [
+        {
+          "datasource": {
+            "type": "grafana-x-ray-datasource",
+            "uid": "${xrayDatasource}"
+          },
+          "group": {
+            "GroupARN": "default",
+            "GroupName": "Default",
+            "InsightsConfiguration": {
+              "InsightsEnabled": true,
+              "NotificationsEnabled": true
+            }
+          },
+          "includeLinkedAccounts": true,
+          "query": "",
+          "queryMode": "Services",
+          "queryType": "getTraceSummaries",
+          "refId": "A",
+          "region": "$region",
+          "serviceName": "$service",
+          "serviceQueryType": "listServiceOperations",
+          "serviceString": "$service"
+        }
+      ],
+      "title": "${service:text} Operations",
+      "type": "table"
+    },
+    {
+      "datasource": {
+        "type": "grafana-x-ray-datasource",
+        "uid": "${xrayDatasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "custom": {
+            "align": "auto",
+            "cellOptions": {
+              "type": "auto"
+            },
+            "inspect": false
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 12,
+        "x": 12,
+        "y": 31
+      },
+      "id": 3,
+      "options": {
+        "cellHeight": "sm",
+        "footer": {
+          "countRows": false,
+          "fields": "",
+          "reducer": ["sum"],
+          "show": false
+        },
+        "showHeader": true
+      },
+      "pluginVersion": "12.1.0-pre",
+      "targets": [
+        {
+          "accountId": "$account",
+          "datasource": {
+            "type": "grafana-x-ray-datasource",
+            "uid": "${xrayDatasource}"
+          },
+          "group": {
+            "GroupARN": "default",
+            "GroupName": "Default",
+            "InsightsConfiguration": {
+              "InsightsEnabled": true,
+              "NotificationsEnabled": true
+            }
+          },
+          "includeLinkedAccounts": true,
+          "operationName": "$operation",
+          "query": "",
+          "queryMode": "Services",
+          "queryType": "getTraceSummaries",
+          "refId": "A",
+          "region": "$region",
+          "serviceName": "$service",
+          "serviceQueryType": "listServiceLevelObjectives",
+          "serviceString": "$service"
+        }
+      ],
+      "title": "${service:text} $operation SLOS",
+      "type": "table"
+    },
+    {
+      "datasource": {
+        "type": "cloudwatch",
+        "uid": "${cloudwatchDatasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 0,
+        "y": 38
+      },
+      "id": 8,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "12.1.0-pre",
+      "targets": [
+        {
+          "accountId": "$account",
+          "datasource": {
+            "type": "cloudwatch",
+            "uid": "${cloudwatchDatasource}"
+          },
+          "dimensions": {
+            "Environment": "$environment",
+            "Operation": "$operation",
+            "Service": "${service:text}"
+          },
+          "expression": "",
+          "id": "",
+          "label": "",
+          "logGroups": [],
+          "matchExact": true,
+          "metricEditorMode": 0,
+          "metricName": "Latency",
+          "metricQueryType": 0,
+          "namespace": "ApplicationSignals",
+          "period": "",
+          "queryLanguage": "CWLI",
+          "queryMode": "Metrics",
+          "refId": "A",
+          "region": "$region",
+          "sqlExpression": "",
+          "statistic": "Average"
+        }
+      ],
+      "title": "${operation} Latency",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "cloudwatch",
+        "uid": "${cloudwatchDatasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 8,
+        "y": 38
+      },
+      "id": 25,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "12.1.0-pre",
+      "targets": [
+        {
+          "accountId": "$account",
+          "datasource": {
+            "type": "cloudwatch",
+            "uid": "${cloudwatchDatasource}"
+          },
+          "dimensions": {
+            "Environment": "$environment",
+            "Operation": "$operation",
+            "Service": "${service:text}"
+          },
+          "expression": "",
+          "id": "",
+          "label": "",
+          "logGroups": [],
+          "matchExact": true,
+          "metricEditorMode": 0,
+          "metricName": "Error",
+          "metricQueryType": 0,
+          "namespace": "ApplicationSignals",
+          "period": "",
+          "queryLanguage": "CWLI",
+          "queryMode": "Metrics",
+          "refId": "A",
+          "region": "$region",
+          "sqlExpression": "",
+          "statistic": "Average"
+        }
+      ],
+      "title": "${operation} Error",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "cloudwatch",
+        "uid": "${cloudwatchDatasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 16,
+        "y": 38
+      },
+      "id": 26,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "12.1.0-pre",
+      "targets": [
+        {
+          "accountId": "$account",
+          "datasource": {
+            "type": "cloudwatch",
+            "uid": "${cloudwatchDatasource}"
+          },
+          "dimensions": {
+            "Environment": "$environment",
+            "Operation": "$operation",
+            "Service": "${service:text}"
+          },
+          "expression": "",
+          "id": "",
+          "label": "",
+          "logGroups": [],
+          "matchExact": true,
+          "metricEditorMode": 0,
+          "metricName": "Fault",
+          "metricQueryType": 0,
+          "namespace": "ApplicationSignals",
+          "period": "",
+          "queryLanguage": "CWLI",
+          "queryMode": "Metrics",
+          "refId": "A",
+          "region": "$region",
+          "sqlExpression": "",
+          "statistic": "Average"
+        }
+      ],
+      "title": "${operation} Fault",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 46
+      },
+      "id": 16,
+      "panels": [],
+      "title": "${service:text} Dependencies",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "grafana-x-ray-datasource",
+        "uid": "${xrayDatasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "custom": {
+            "align": "auto",
+            "cellOptions": {
+              "type": "auto"
+            },
+            "inspect": false
+          },
+          "links": [
+            {
+              "title": "Use dependency",
+              "url": "/d/4a42f43f-6e29-41df-8037-3f3bb504e05f?var-dependencyDimensions=${__data.fields.Dimensions}﻿﻿&var-dependency=﻿${__data.fields.DependencyOperationName}"
+            }
+          ],
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 24,
+        "x": 0,
+        "y": 47
+      },
+      "id": 4,
+      "options": {
+        "cellHeight": "sm",
+        "footer": {
+          "countRows": false,
+          "fields": "",
+          "reducer": ["sum"],
+          "show": false
+        },
+        "showHeader": true,
+        "sortBy": [
+          {
+            "desc": false,
+            "displayName": "DependencyOperationName"
+          }
+        ]
+      },
+      "pluginVersion": "12.1.0-pre",
+      "targets": [
+        {
+          "datasource": {
+            "type": "grafana-x-ray-datasource",
+            "uid": "${xrayDatasource}"
+          },
+          "group": {
+            "GroupARN": "default",
+            "GroupName": "Default",
+            "InsightsConfiguration": {
+              "InsightsEnabled": true,
+              "NotificationsEnabled": true
+            }
+          },
+          "query": "",
+          "queryMode": "Services",
+          "queryType": "getTraceSummaries",
+          "refId": "A",
+          "region": "$region",
+          "serviceName": "$service",
+          "serviceQueryType": "listServiceDependencies",
+          "serviceString": "$service"
+        }
+      ],
+      "title": "${service:text} Dependencies",
+      "type": "table"
+    },
+    {
+      "datasource": {
+        "type": "cloudwatch",
+        "uid": "${cloudwatchDatasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 0,
+        "y": 54
+      },
+      "id": 11,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "12.1.0-pre",
+      "targets": [
+        {
+          "accountId": "$account",
+          "datasource": {
+            "type": "cloudwatch",
+            "uid": "${cloudwatchDatasource}"
+          },
+          "dimensions": {},
+          "expression": "REMOVE_EMPTY(SEARCH('Namespace=\"ApplicationSignals\" MetricName=\"Latency\" $dependencyDimensions', 'Average', 60))",
+          "id": "",
+          "label": "",
+          "logGroups": [],
+          "matchExact": true,
+          "metricEditorMode": 1,
+          "metricName": "Latency",
+          "metricQueryType": 0,
+          "namespace": "ApplicationSignals",
+          "period": "",
+          "queryLanguage": "CWLI",
+          "queryMode": "Metrics",
+          "refId": "A",
+          "region": "$region",
+          "sqlExpression": "",
+          "statistic": "Average"
+        }
+      ],
+      "title": "${dependency} Latency",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "cloudwatch",
+        "uid": "${cloudwatchDatasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 8,
+        "y": 54
+      },
+      "id": 29,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "12.1.0-pre",
+      "targets": [
+        {
+          "accountId": "$account",
+          "datasource": {
+            "type": "cloudwatch",
+            "uid": "${cloudwatchDatasource}"
+          },
+          "dimensions": {},
+          "expression": "REMOVE_EMPTY(SEARCH('Namespace=\"ApplicationSignals\" MetricName=\"Error\" $dependencyDimensions', 'Average', 60))",
+          "id": "",
+          "label": "",
+          "logGroups": [],
+          "matchExact": true,
+          "metricEditorMode": 1,
+          "metricName": "Latency",
+          "metricQueryType": 0,
+          "namespace": "ApplicationSignals",
+          "period": "",
+          "queryLanguage": "CWLI",
+          "queryMode": "Metrics",
+          "refId": "A",
+          "region": "$region",
+          "sqlExpression": "",
+          "statistic": "Average"
+        }
+      ],
+      "title": "${dependency} Error",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "cloudwatch",
+        "uid": "${cloudwatchDatasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 16,
+        "y": 54
+      },
+      "id": 30,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "12.1.0-pre",
+      "targets": [
+        {
+          "accountId": "$account",
+          "datasource": {
+            "type": "cloudwatch",
+            "uid": "${cloudwatchDatasource}"
+          },
+          "dimensions": {},
+          "expression": "REMOVE_EMPTY(SEARCH('Namespace=\"ApplicationSignals\" MetricName=\"Fault\" $dependencyDimensions', 'Average', 60))",
+          "id": "",
+          "label": "",
+          "logGroups": [],
+          "matchExact": true,
+          "metricEditorMode": 1,
+          "metricName": "Latency",
+          "metricQueryType": 0,
+          "namespace": "ApplicationSignals",
+          "period": "",
+          "queryLanguage": "CWLI",
+          "queryMode": "Metrics",
+          "refId": "A",
+          "region": "$region",
+          "sqlExpression": "",
+          "statistic": "Average"
+        }
+      ],
+      "title": "${dependency} Fault",
+      "type": "timeseries"
+    }
+  ],
+  "preload": false,
+  "schemaVersion": 41,
+  "tags": [],
+  "templating": {
+    "list": [
+      {
+        "current": {},
+        "name": "xrayDatasource",
+        "options": [],
+        "query": "grafana-x-ray-datasource",
+        "refresh": 1,
+        "regex": "",
+        "type": "datasource"
+      },
+      {
+        "current": {},
+        "name": "cloudwatchDatasource",
+        "options": [],
+        "query": "cloudwatch",
+        "refresh": 1,
+        "regex": "",
+        "type": "datasource"
+      },
+      {
+        "current": {},
+        "datasource": {
+          "type": "grafana-x-ray-datasource",
+          "uid": "${xrayDatasource}"
+        },
+        "definition": "",
+        "name": "region",
+        "options": [],
+        "query": {
+          "queryType": "regions"
+        },
+        "refresh": 1,
+        "regex": "",
+        "type": "query"
+      },
+      {
+        "current": {},
+        "datasource": {
+          "type": "grafana-x-ray-datasource",
+          "uid": "${xrayDatasource}"
+        },
+        "definition": "",
+        "name": "account",
+        "options": [],
+        "query": {
+          "group": {
+            "GroupARN": "default",
+            "GroupName": "Default",
+            "InsightsConfiguration": {
+              "InsightsEnabled": true,
+              "NotificationsEnabled": true
+            }
+          },
+          "groupName": "Default",
+          "queryType": "accounts",
+          "region": "$region"
+        },
+        "refresh": 1,
+        "regex": "",
+        "type": "query"
+      },
+      {
+        "current": {},
+        "datasource": {
+          "type": "grafana-x-ray-datasource",
+          "uid": "${xrayDatasource}"
+        },
+        "definition": "",
+        "hide": 2,
+        "name": "service",
+        "options": [],
+        "query": {
+          "accountId": "$account",
+          "group": {
+            "GroupARN": "default",
+            "GroupName": "Default",
+            "InsightsConfiguration": {
+              "InsightsEnabled": true,
+              "NotificationsEnabled": true
+            }
+          },
+          "queryType": "services",
+          "region": "$region"
+        },
+        "refresh": 1,
+        "regex": "",
+        "type": "query"
+      },
+      {
+        "current": {},
+        "datasource": {
+          "type": "grafana-x-ray-datasource",
+          "uid": "${xrayDatasource}"
+        },
+        "definition": "",
+        "hide": 2,
+        "name": "operation",
+        "options": [],
+        "query": {
+          "queryType": "operations",
+          "region": "$region",
+          "serviceName": "$service",
+          "serviceString": "$service"
+        },
+        "refresh": 1,
+        "regex": "",
+        "type": "query"
+      },
+      {
+        "current": {
+          "text": "",
+          "value": ""
+        },
+        "hide": 2,
+        "name": "operationDimensions",
+        "options": [],
+        "query": "",
+        "type": "custom"
+      },
+      {
+        "current": {
+          "text": "",
+          "value": ""
+        },
+        "hide": 2,
+        "name": "dependencyDimensions",
+        "options": [],
+        "query": "",
+        "type": "custom"
+      },
+      {
+        "current": {
+          "text": "",
+          "value": ""
+        },
+        "hide": 2,
+        "name": "dependency",
+        "options": [],
+        "query": "",
+        "type": "custom"
+      },
+      {
+        "current": {
+          "text": "",
+          "value": ""
+        },
+        "hide": 2,
+        "name": "environment",
+        "options": [],
+        "query": "",
+        "type": "custom"
+      }
+    ]
+  },
+  "time": {
+    "from": "now-6h",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "browser",
+  "title": "Application Signals: Services",
+  "uid": "4a42f43f-6e29-41df-8037-3f3bb504e05f",
+  "version": 20,
+  "weekStart": ""
+}

--- a/src/plugin.json
+++ b/src/plugin.json
@@ -8,6 +8,13 @@
   "backend": true,
   "alerting": true,
   "executable": "gpx_x-ray-datasource",
+  "includes": [
+    {
+      "type": "dashboard",
+      "name": "X-Ray App Signals",
+      "path": "dashboards/xray-app-signals.json"
+    }
+  ],
   "info": {
     "description": "Data source for AWS Application Signals",
     "author": {

--- a/src/variables.ts
+++ b/src/variables.ts
@@ -47,7 +47,9 @@ export class XrayVariableSupport extends CustomVariableSupport<XrayDataSource, X
         case VariableQueryType.Groups:
           return groupsToVariables(await this.datasource.getGroups(query.region, scopedVars));
         case VariableQueryType.Accounts:
-          return (await this.datasource.getAccountIds(range, query.groupName, scopedVars)).map(toOption);
+          const accountIds = (await this.datasource.getAccountIds(range, query.groupName, scopedVars)).map(toOption);
+          accountIds.push({ value: 'all', text: 'All' });
+          return accountIds;
         case VariableQueryType.Services:
           return (await this.datasource.getServices(query.region, range, query.accountId, scopedVars)).map(
             serviceToVariables


### PR DESCRIPTION
Not sure this is merge ready yet (I don't know if this is the finalized blurb) but this should be the dashboard in terms of functionality.

Also had to update the backend queries to treat a "all" value for accountId as "" so that I could use the same accountId for cloudwatch and x-ray.

The dashboard can be imported from the datasource page. To use app signals queries you need to have app signals permissions (the user group `xray_dev` in the external account has all the necessary permissions)