### PR TITLE
Prepare 2.16.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 All notable changes to this project will be documented in this file.
 
+## 2.16.2
+
+- Dependencies: Bump grafana dependencies and run create-plugin update in [#429](https://github.com/grafana/x-ray-datasource/pull/429)
+- Bump eslint from 9.27.0 to 9.30.1 in [#418](https://github.com/grafana/x-ray-datasource/pull/418)
+- Bump eslint-config-prettier from 10.1.5 to 10.1.8 in [#415](https://github.com/grafana/x-ray-datasource/pull/415)
+- Bump webpack from 5.99.9 to 5.100.1 in [#423](https://github.com/grafana/x-ray-datasource/pull/423)
+- Bump @types/node from 22.16.4 to 22.16.5 in [#430](https://github.com/grafana/x-ray-datasource/pull/430)
+- Bump @grafana/eslint-config from 8.0.0 to 8.1.0 in [#416](https://github.com/grafana/x-ray-datasource/pull/416)
+
 ## 2.16.1
 
 - Chore: Use CI/CD actions for e2e and update grafana version in plugin.json by @idastambuk in https://github.com/grafana/x-ray-datasource/pull/421

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "grafana-x-ray-datasource",
-  "version": "2.16.1",
+  "version": "2.16.2",
   "description": "AWS Application Signals data source",
   "scripts": {
     "build": "webpack -c ./.config/webpack/webpack.config.ts --env production",


### PR DESCRIPTION
## 2.16.2

- Dependencies: Bump grafana dependencies and run create-plugin update in [#429](https://github.com/grafana/x-ray-datasource/pull/429)
- Bump eslint from 9.27.0 to 9.30.1 in [#418](https://github.com/grafana/x-ray-datasource/pull/418)
- Bump eslint-config-prettier from 10.1.5 to 10.1.8 in [#415](https://github.com/grafana/x-ray-datasource/pull/415)
- Bump webpack from 5.99.9 to 5.100.1 in [#423](https://github.com/grafana/x-ray-datasource/pull/423)
- Bump @types/node from 22.16.4 to 22.16.5 in [#430](https://github.com/grafana/x-ray-datasource/pull/430)
- Bump @grafana/eslint-config from 8.0.0 to 8.1.0 in [#416](https://github.com/grafana/x-ray-datasource/pull/416)

