### PR TITLE
fix(getServiceMap): fall back to default group when Group is nil or empty

### DIFF
--- a/pkg/datasource/datasource_test.go
+++ b/pkg/datasource/datasource_test.go
@@ -743,6 +743,23 @@ func TestDatasource(t *testing.T) {
 		require.True(t, strings.Contains(frame.Fields[0].At(0).(string), "mockServiceName-us-east-1"))
 	})
 
+	// Regression test for #635 — a panel imported from JSON (or created via API)
+	// may arrive without a Group populated. Must fall back to the default group
+	// instead of panicking on nil dereference.
+	t.Run("getServiceMap query with nil group does not panic", func(t *testing.T) {
+		response, err := queryDatasource(ds, datasource.QueryGetServiceMap, datasource.GetServiceMapQueryData{})
+		require.NoError(t, err)
+		require.NoError(t, response.Responses["A"].Error)
+		require.Equal(t, 2, response.Responses["A"].Frames[0].Fields[0].Len())
+	})
+
+	t.Run("getServiceMap query with group present but GroupName nil does not panic", func(t *testing.T) {
+		response, err := queryDatasource(ds, datasource.QueryGetServiceMap, datasource.GetServiceMapQueryData{Group: &xraytypes.Group{}})
+		require.NoError(t, err)
+		require.NoError(t, response.Responses["A"].Error)
+		require.Equal(t, 2, response.Responses["A"].Frames[0].Fields[0].Len())
+	})
+
 	//
 	// RootCauseError
 	//

--- a/pkg/datasource/getServiceMap.go
+++ b/pkg/datasource/getServiceMap.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 
+	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/xray"
 	xraytypes "github.com/aws/aws-sdk-go-v2/service/xray/types"
 
@@ -11,6 +12,13 @@ import (
 	"github.com/grafana/grafana-plugin-sdk-go/backend/log"
 	"github.com/grafana/grafana-plugin-sdk-go/data"
 )
+
+// defaultGroupName is used when the request has no Group (or an empty
+// GroupName) set — for example when a panel was created via the API or a
+// dashboard JSON import rather than the query editor, which normally
+// populates the field on open. Without this fallback, dereferencing
+// Group.GroupName panics in getSingleServiceMap. See issue #635.
+const defaultGroupName = "Default"
 
 type GetServiceMapQueryData struct {
 	Region     string           `json:"region"`
@@ -38,10 +46,16 @@ func (ds *Datasource) getSingleServiceMap(ctx context.Context, query backend.Dat
 	)
 
 	log.DefaultLogger.Debug("getSingleServiceMap", "RefID", query.RefID)
+
+	groupName := aws.String(defaultGroupName)
+	if queryData.Group != nil && queryData.Group.GroupName != nil && *queryData.Group.GroupName != "" {
+		groupName = queryData.Group.GroupName
+	}
+
 	input := &xray.GetServiceGraphInput{
 		StartTime: &query.TimeRange.From,
 		EndTime:   &query.TimeRange.To,
-		GroupName: queryData.Group.GroupName,
+		GroupName: groupName,
 	}
 
 	accountIdsToFilterBy := make(map[string]bool)


### PR DESCRIPTION
## Summary

Fixes #635 — `getSingleServiceMap` panics with a nil pointer dereference when a panel arrives at the backend without a `Group` populated (e.g. a panel created via API or imported from dashboard JSON, which bypasses the query-editor code path that normally sets the group).

## What changed

- Nil-check `queryData.Group` and `queryData.Group.GroupName` in `pkg/datasource/getServiceMap.go`; fall back to the `"Default"` X-Ray group when either is missing or empty, matching the behavior @iwysiu suggested in the issue.
- Added two regression tests:
  - `getServiceMap query with nil group does not panic` — covers the exact repro from the bug report.
  - `getServiceMap query with group present but GroupName nil does not panic` — covers the related shape where the struct is populated but the name field is empty.

## Out of scope for this PR

The issue also suggests updating `processRequest` on the frontend (via `useGroups` + `useInitQuery`) to populate the group when it's nil. Keeping that out of this PR so the backend panic fix can ship cleanly — happy to follow up in a separate PR if desired.

## Testing

- `go test ./... -count=1` → 38 passed across 3 packages.
- Existing serviceMap tests still pass.

Fixes #635