### PR TITLE
fix: prevent nil pointer dereference when service map query group is empty

### DIFF
--- a/pkg/datasource/datasource_test.go
+++ b/pkg/datasource/datasource_test.go
@@ -21,9 +21,12 @@ import (
 
 type XrayClientMock struct {
 	queryCalledWithRegion string
+	getServiceGraphInput  *xray.GetServiceGraphInput
 }
 
-func (client *XrayClientMock) GetServiceGraph(_ context.Context, _ *xray.GetServiceGraphInput, _ ...func(*xray.Options)) (*xray.GetServiceGraphOutput, error) {
+func (client *XrayClientMock) GetServiceGraph(_ context.Context, input *xray.GetServiceGraphInput, _ ...func(*xray.Options)) (*xray.GetServiceGraphOutput, error) {
+	client.getServiceGraphInput = input
+
 	serviceName := "mockServiceName"
 	if client.queryCalledWithRegion != "" {
 		serviceName = serviceName + "-" + client.queryCalledWithRegion
@@ -730,6 +733,23 @@ func TestDatasource(t *testing.T) {
 		// Bit simplistic test but right now we just send each service as a json to frontend and do transform there.
 		frame := response.Responses["A"].Frames[0]
 		require.Equal(t, 2, frame.Fields[0].Len()) // 2 because of the 2 services added to the mock
+	})
+
+	t.Run("getServiceMap query defaults missing group", func(t *testing.T) {
+		xrayMock := &XrayClientMock{}
+		ds := datasource.NewDatasource(
+			context.Background(),
+			func(context.Context, backend.PluginContext, datasource.RequestSettings) (datasource.XrayClient, error) {
+				return xrayMock, nil
+			},
+			appSignalsClientFactory,
+			settings,
+		)
+
+		response, err := queryDatasource(ds, datasource.QueryGetServiceMap, datasource.GetServiceMapQueryData{})
+		require.NoError(t, err)
+		require.NoError(t, response.Responses["A"].Error)
+		require.Equal(t, "Default", aws.ToString(xrayMock.getServiceGraphInput.GroupName))
 	})
 
 	t.Run("getServiceMap query with region", func(t *testing.T) {

--- a/pkg/datasource/getServiceMap.go
+++ b/pkg/datasource/getServiceMap.go
@@ -3,8 +3,8 @@ package datasource
 import (
 	"context"
 	"encoding/json"
-	"fmt"
 
+	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/xray"
 	xraytypes "github.com/aws/aws-sdk-go-v2/service/xray/types"
 
@@ -28,10 +28,6 @@ func (ds *Datasource) getSingleServiceMap(ctx context.Context, query backend.Dat
 		return backend.ErrorResponseWithErrorSource(backend.PluginError(err))
 	}
 
-	if queryData.Group == nil {
-		return backend.ErrorResponseWithErrorSource(backend.PluginError(fmt.Errorf("group is required")))
-	}
-
 	xrayClient, err := ds.getClient(ctx, pluginContext, RequestSettings{Region: queryData.Region})
 	if err != nil {
 		return backend.ErrorResponseWithErrorSource(backend.PluginError(err))
@@ -43,10 +39,15 @@ func (ds *Datasource) getSingleServiceMap(ctx context.Context, query backend.Dat
 	)
 
 	log.DefaultLogger.Debug("getSingleServiceMap", "RefID", query.RefID)
+	groupName := aws.String("Default")
+	if queryData.Group != nil && queryData.Group.GroupName != nil {
+		groupName = queryData.Group.GroupName
+	}
+
 	input := &xray.GetServiceGraphInput{
 		StartTime: &query.TimeRange.From,
 		EndTime:   &query.TimeRange.To,
-		GroupName: queryData.Group.GroupName,
+		GroupName: groupName,
 	}
 
 	accountIdsToFilterBy := make(map[string]bool)

--- a/pkg/datasource/getServiceMap.go
+++ b/pkg/datasource/getServiceMap.go
@@ -3,6 +3,7 @@ package datasource
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 
 	"github.com/aws/aws-sdk-go-v2/service/xray"
 	xraytypes "github.com/aws/aws-sdk-go-v2/service/xray/types"
@@ -25,6 +26,10 @@ func (ds *Datasource) getSingleServiceMap(ctx context.Context, query backend.Dat
 
 	if err != nil {
 		return backend.ErrorResponseWithErrorSource(backend.PluginError(err))
+	}
+
+	if queryData.Group == nil {
+		return backend.ErrorResponseWithErrorSource(backend.PluginError(fmt.Errorf("group is required")))
 	}
 
 	xrayClient, err := ds.getClient(ctx, pluginContext, RequestSettings{Region: queryData.Region})


### PR DESCRIPTION
## Description

Fixes #635 - nil pointer dereference in getServiceMap when the query filter expression is empty (e.g., a Grafana template variable that resolves to an empty string for an "All" option).

**Root Cause:** queryData.Group can be 
il after JSON unmarshaling when the group field is not present or empty. Accessing .GroupName on a nil pointer panics the plugin.

**Fix:** Add a nil check for queryData.Group after unmarshaling, returning a clear error message if it is nil.