### PR TITLE
fix(getServiceMap): fall back to Default group when Group is nil or empty

### DIFF
--- a/pkg/datasource/datasource_test.go
+++ b/pkg/datasource/datasource_test.go
@@ -743,6 +743,23 @@ func TestDatasource(t *testing.T) {
 		require.True(t, strings.Contains(frame.Fields[0].At(0).(string), "mockServiceName-us-east-1"))
 	})
 
+	// Regression test for #635 — a panel imported from JSON (or created via API)
+	// may arrive without a Group populated. Must fall back to the default group
+	// instead of panicking on nil dereference.
+	t.Run("getServiceMap query with nil group does not panic", func(t *testing.T) {
+		response, err := queryDatasource(ds, datasource.QueryGetServiceMap, datasource.GetServiceMapQueryData{})
+		require.NoError(t, err)
+		require.NoError(t, response.Responses["A"].Error)
+		require.Equal(t, 2, response.Responses["A"].Frames[0].Fields[0].Len())
+	})
+
+	t.Run("getServiceMap query with group present but GroupName nil does not panic", func(t *testing.T) {
+		response, err := queryDatasource(ds, datasource.QueryGetServiceMap, datasource.GetServiceMapQueryData{Group: &xraytypes.Group{}})
+		require.NoError(t, err)
+		require.NoError(t, response.Responses["A"].Error)
+		require.Equal(t, 2, response.Responses["A"].Frames[0].Fields[0].Len())
+	})
+
 	//
 	// RootCauseError
 	//

--- a/pkg/datasource/getServiceMap.go
+++ b/pkg/datasource/getServiceMap.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 
+	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/xray"
 	xraytypes "github.com/aws/aws-sdk-go-v2/service/xray/types"
 
@@ -11,6 +12,13 @@ import (
 	"github.com/grafana/grafana-plugin-sdk-go/backend/log"
 	"github.com/grafana/grafana-plugin-sdk-go/data"
 )
+
+// defaultGroupName is used when the request has no Group (or an empty
+// GroupName) set — for example when a panel was created via the API or a
+// dashboard JSON import rather than the query editor, which normally
+// populates the field on open. Without this fallback, dereferencing
+// Group.GroupName panics in getSingleServiceMap. See issue #635.
+const defaultGroupName = "Default"
 
 type GetServiceMapQueryData struct {
 	Region     string           `json:"region"`
@@ -38,10 +46,16 @@ func (ds *Datasource) getSingleServiceMap(ctx context.Context, query backend.Dat
 	)
 
 	log.DefaultLogger.Debug("getSingleServiceMap", "RefID", query.RefID)
+
+	groupName := aws.String(defaultGroupName)
+	if queryData.Group != nil && queryData.Group.GroupName != nil && *queryData.Group.GroupName != "" {
+		groupName = queryData.Group.GroupName
+	}
+
 	input := &xray.GetServiceGraphInput{
 		StartTime: &query.TimeRange.From,
 		EndTime:   &query.TimeRange.To,
-		GroupName: queryData.Group.GroupName,
+		GroupName: groupName,
 	}
 
 	accountIdsToFilterBy := make(map[string]bool)


### PR DESCRIPTION
## Summary
- Guard `getSingleServiceMap` against a nil/empty X-Ray `Group` (common for panels created via API or imported dashboard JSON).
- Fall back to the `Default` group name instead of panicking on `Group.GroupName` dereference.
- Add regression tests covering nil `Group` and nil `GroupName`.

Fixes #635

## Test plan
- [x] `go test ./pkg/datasource/ -count=1 -run 'TestDatasource/getServiceMap'`
- [ ] Reproduce with a service map panel that omits `group` in JSON and confirm no plugin panic