### PR TITLE
test: add X-Ray Cloud E2E coverage

### DIFF
--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -2,7 +2,7 @@ name: Scheduled Cloud E2E tests
 
 on:
   schedule:
-    - cron: '0 9 * * *' # Daily at 09:00 UTC
+    - cron: '0 6 * * *' # Daily at 06:00 UTC
   workflow_dispatch:
 
 permissions:
@@ -11,7 +11,7 @@ permissions:
 
 jobs:
   playwright-cloud:
-    uses: grafana/data-sources-ci-workflows/.github/workflows/playwright-cloud.yml@30b5f942cd28a87dc2c4556956604c60bd096900 # main
+    uses: grafana/data-sources-ci-workflows/.github/workflows/playwright-cloud.yml@main
     secrets: inherit
     permissions:
       contents: read

--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -1,0 +1,29 @@
+name: Scheduled Cloud E2E tests
+
+on:
+  schedule:
+    - cron: '0 9 * * *' # Daily at 09:00 UTC
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  playwright-cloud:
+    uses: grafana/data-sources-ci-workflows/.github/workflows/playwright-cloud.yml@30b5f942cd28a87dc2c4556956604c60bd096900 # main
+    secrets: inherit
+    permissions:
+      contents: read
+      id-token: write
+    with:
+      run-stage: nightly
+      # Reusable-workflow inputs are resolved before Vault secrets are fetched.
+      pdc-network-name: datasources-pdc-network-aws-datasourcese2e
+      bench-prepare-cmd: yarn install --immutable && yarn playwright install chromium
+      bench-execute-cmd: yarn e2e --grep @aws
+      repo-secrets: |
+        AWS_ACCESS_KEY_ID=xray:secure_accessKey
+        AWS_SECRET_ACCESS_KEY=xray:secure_secretKey
+        AWS_DEFAULT_REGION=xray:json_defaultRegion
+        DS_PDC_NETWORK_NAME=xray:e2ePdcNetworkName

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -17,6 +17,20 @@ jobs:
       id-token: write
     with:
       plugin-version-suffix: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || '' }}
+      playwright-config: ${{ (github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork) && 'playwright.smoke.config.ts' || 'playwright.config.ts' }}
       playwright-secrets: |
-        AWS_ACCESS_KEY_ID=e2e:accessKey
-        AWS_SECRET_ACCESS_KEY=e2e:secretKey
+        AWS_ACCESS_KEY_ID=xray:secure_accessKey
+        AWS_SECRET_ACCESS_KEY=xray:secure_secretKey
+        AWS_DEFAULT_REGION=xray:json_defaultRegion
+
+  publish-and-deploy:
+    if: github.ref == 'refs/heads/main'
+    uses: grafana/data-sources-ci-workflows/.github/workflows/cd-dev.yml@d0cd847270085524b96b0e1aebc0cb3efd121c40 # main
+    permissions:
+      attestations: write
+      contents: write
+      id-token: write
+      pull-requests: read
+    with:
+      go-version: '1.26.3'
+      golangci-lint-version: '2.12.2'

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -61,9 +61,13 @@ bra run
 
 1. Ensure you have the `AWS X-Ray E2E` data source provisioned in the `provisioning/datasources` directory
 
-2. Start the server
+2. Export live AWS test credentials, then start the server. The provisioning file reads these values when Grafana starts.
 
 ```sh
+export AWS_ACCESS_KEY_ID='your-access-key-id'
+export AWS_SECRET_ACCESS_KEY='your-secret-access-key'
+export AWS_DEFAULT_REGION='us-east-2'
+
 yarn server
 ```
 
@@ -76,6 +80,8 @@ yarn e2e
 yarn e2e:report
 
 ```
+
+When running against Grafana Cloud, set `DS_PDC_NETWORK_NAME` to select a Private Data Source Connect network.
 
 ## Building a release
 

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -21,7 +21,7 @@ export default defineConfig({
   /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
   use: {
     /* Base URL to use in actions like `await page.goto('/')`. */
-    baseURL: 'http://localhost:3000',
+    baseURL: process.env.GRAFANA_URL || 'http://localhost:3000',
 
     /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
     trace: 'on-first-retry',
@@ -39,7 +39,7 @@ export default defineConfig({
       use: {
         ...devices['Desktop Chrome'],
         viewport: { width: 1920, height: 1080 },
-        storageState: 'playwright/.auth/admin.json',
+        storageState: `playwright/.auth/${process.env.GRAFANA_ADMIN_USER || 'admin'}.json`,
       },
       dependencies: ['authenticate'],
     },

--- a/playwright.smoke.config.ts
+++ b/playwright.smoke.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from '@playwright/test';
+
+import baseConfig from './playwright.config';
+
+// Fork PRs cannot read Vault secrets, so exclude tests that require the live AWS backend.
+export default defineConfig(baseConfig, {
+  grepInvert: /@aws/,
+});

--- a/tests/config-editor.spec.ts
+++ b/tests/config-editor.spec.ts
@@ -1,9 +1,48 @@
 import { test, expect } from '@grafana/plugin-e2e';
+import type { Page } from '@playwright/test';
+
+const PLUGIN_TYPE = 'grafana-x-ray-datasource';
+
+async function configurePDC(page: Page, networkName: string) {
+  await page.getByRole('combobox', { name: 'Private data source connect' }).click();
+  await page.getByText(networkName, { exact: true }).click();
+}
 
 test('invalid credentials should return an error', async ({ createDataSourceConfigPage, page }) => {
-  const configPage = await createDataSourceConfigPage({ type: 'grafana-x-ray-datasource' });
+  const configPage = await createDataSourceConfigPage({ type: PLUGIN_TYPE });
 
   await page.getByLabel('Assume Role ARN').fill('arn::role/error-role');
 
   await expect(configPage.saveAndTest()).not.toBeOK();
 });
+
+test(
+  'valid injected credentials should pass the health check',
+  { tag: '@aws' },
+  async ({ createDataSourceConfigPage, page }) => {
+    const accessKey = process.env.AWS_ACCESS_KEY_ID;
+    const secretKey = process.env.AWS_SECRET_ACCESS_KEY;
+    const region = process.env.AWS_DEFAULT_REGION;
+    const hasCredentials = !!accessKey && !!secretKey && !!region;
+
+    // Trusted PR CI provisions Grafana from Docker's .env, but does not expose those
+    // values to Playwright. The credential-entry flow runs in Bench or with local exports.
+    test.skip(!process.env.GRAFANA_URL && !hasCredentials, 'Requires injected AWS credentials');
+    expect(hasCredentials, 'Cloud E2E must inject AWS credentials into Playwright').toBe(true);
+
+    const configPage = await createDataSourceConfigPage({ type: PLUGIN_TYPE });
+
+    await page.getByRole('combobox', { name: 'Authentication Provider', exact: true }).click();
+    await page.getByText('Access & secret key', { exact: true }).click();
+    await page.getByLabel('Access Key ID').fill(accessKey ?? '');
+    await page.getByLabel('Secret Access Key').fill(secretKey ?? '');
+    await page.getByLabel('Default Region').click();
+    await page.getByText(region ?? '', { exact: true }).click();
+
+    if (process.env.DS_PDC_NETWORK_NAME) {
+      await configurePDC(page, process.env.DS_PDC_NETWORK_NAME);
+    }
+
+    await expect(configPage.saveAndTest()).toBeOK();
+  }
+);

--- a/tests/query-editor.spec.ts
+++ b/tests/query-editor.spec.ts
@@ -1,5 +1,10 @@
 import { test, expect } from '@grafana/plugin-e2e';
 
+const isCloudRun = !!process.env.GRAFANA_URL;
+const DATA_SOURCE_NAME = isCloudRun ? '[managed_data_source] - X-Ray (PDC)' : 'AWS X-Ray E2E';
+
+test.describe.configure({ mode: 'serial', timeout: 60_000 });
+
 // Disable the new dashboard layouts so plugin-e2e's addPanel() helper uses the
 // stable "Add panel" flow instead of the sidebar/edit-pane path.
 //
@@ -14,91 +19,107 @@ import { test, expect } from '@grafana/plugin-e2e';
 // bundled @grafana/e2e-selectors includes the Grafana 13.2.0 sidebar selectors.
 test.use({ featureToggles: { dashboardNewLayouts: false } });
 
-test('data query is successful when `Trace List` query is valid', async ({ page, panelEditPage, selectors }) => {
-  await panelEditPage.datasource.set('AWS X-Ray E2E');
-  await panelEditPage.setVisualization('Table');
+test(
+  'data query is successful when `Trace List` query is valid',
+  { tag: '@aws' },
+  async ({ page, panelEditPage, selectors }) => {
+    await panelEditPage.datasource.set(DATA_SOURCE_NAME);
+    await panelEditPage.setVisualization('Table');
 
-  await panelEditPage.getByGrafanaSelector(selectors.components.QueryField.container).click();
-  await page.keyboard.insertText('service("PetSite")');
-  await page.waitForTimeout(500); // Waits for query to update because <QueryField /> debounces onChange
+    await panelEditPage.getByGrafanaSelector(selectors.components.QueryField.container).click();
+    await page.keyboard.insertText('service("PetSite")');
+    await page.waitForTimeout(500); // Waits for query to update because <QueryField /> debounces onChange
 
-  await expect(page.getByRole('button', { name: 'Trace List' })).toBeVisible();
-  await expect(panelEditPage.refreshPanel()).toBeOK();
-  await expect(panelEditPage.panel.getErrorIcon()).not.toBeVisible();
-  await expect(panelEditPage.panel.fieldNames).toHaveText([
-    'Id',
-    'Start Time',
-    'Method',
-    'Response',
-    'Response Time',
-    'URL',
-    'Client IP',
-    'Annotations',
-  ]);
-});
+    await expect(page.getByRole('button', { name: 'Trace List' })).toBeVisible();
+    await expect(panelEditPage.refreshPanel()).toBeOK();
+    await expect(panelEditPage.panel.getErrorIcon()).not.toBeVisible();
+    await expect(panelEditPage.panel.fieldNames).toHaveText([
+      'Id',
+      'Start Time',
+      'Method',
+      'Response',
+      'Response Time',
+      'URL',
+      'Client IP',
+      'Annotations',
+    ]);
+  }
+);
 
-test('data query is successful when `Trace Statistics` query is valid', async ({ page, panelEditPage, selectors }) => {
-  await panelEditPage.datasource.set('AWS X-Ray E2E');
-  await panelEditPage.setVisualization('Table');
+test(
+  'data query is successful when `Trace Statistics` query is valid',
+  { tag: '@aws' },
+  async ({ page, panelEditPage, selectors }) => {
+    await panelEditPage.datasource.set(DATA_SOURCE_NAME);
+    await panelEditPage.setVisualization('Table');
 
-  await panelEditPage.getByGrafanaSelector(selectors.components.QueryField.container).click();
-  await page.keyboard.insertText('service("PetSite")');
-  await page.waitForTimeout(500); // Waits for query to update because <QueryField /> debounces onChange
-  await page.getByRole('button', { name: 'Trace List' }).click();
-  await page.getByRole('menuitemcheckbox', { name: 'Trace Statistics' }).click();
-  await panelEditPage.getByGrafanaSelector(selectors.components.QueryField.container).click(); // Make sure the dropdown is closed
-  await page.getByRole('combobox', { name: 'Columns' }).click();
-  await page.getByText('Total Count').click();
-  await page.keyboard.press('Escape');
+    await panelEditPage.getByGrafanaSelector(selectors.components.QueryField.container).click();
+    await page.keyboard.insertText('service("PetSite")');
+    await page.waitForTimeout(500); // Waits for query to update because <QueryField /> debounces onChange
+    await page.getByRole('button', { name: 'Trace List' }).click();
+    await page.getByRole('menuitemcheckbox', { name: 'Trace Statistics' }).click();
+    await panelEditPage.getByGrafanaSelector(selectors.components.QueryField.container).click(); // Make sure the dropdown is closed
+    await page.getByRole('combobox', { name: 'Columns' }).click();
+    await page.getByText('Total Count').click();
+    await page.keyboard.press('Escape');
 
-  await expect(panelEditPage.refreshPanel()).toBeOK();
-  await expect(panelEditPage.panel.getErrorIcon()).not.toBeVisible();
-  await expect(panelEditPage.panel.fieldNames).toHaveText(['Time', 'Total Count']);
-});
+    await expect(panelEditPage.refreshPanel()).toBeOK();
+    await expect(panelEditPage.panel.getErrorIcon()).not.toBeVisible();
+    await expect(panelEditPage.panel.fieldNames).toHaveText(['Time', 'Total Count']);
+  }
+);
 
-test('data query is successful when `Trace Analytics` query is valid', async ({ page, panelEditPage, selectors }) => {
-  await panelEditPage.datasource.set('AWS X-Ray E2E');
-  await panelEditPage.setVisualization('Table');
+test(
+  'data query is successful when `Trace Analytics` query is valid',
+  { tag: '@aws' },
+  async ({ page, panelEditPage, selectors }) => {
+    await panelEditPage.datasource.set(DATA_SOURCE_NAME);
+    await panelEditPage.setVisualization('Table');
 
-  await panelEditPage.getByGrafanaSelector(selectors.components.QueryField.container).click();
-  await page.keyboard.insertText('service("PetSite")');
-  await page.waitForTimeout(500); // Waits for query to update because <QueryField /> debounces onChange
-  await page.getByRole('button', { name: 'Trace List' }).click();
-  await page.getByRole('menuitemcheckbox', { name: 'Trace Analytics' }).click();
-  await page.getByRole('menuitemcheckbox', { name: 'HTTP status code' }).click();
+    await panelEditPage.getByGrafanaSelector(selectors.components.QueryField.container).click();
+    await page.keyboard.insertText('service("PetSite")');
+    await page.waitForTimeout(500); // Waits for query to update because <QueryField /> debounces onChange
+    await page.getByRole('button', { name: 'Trace List' }).click();
+    await page.getByRole('menuitemcheckbox', { name: 'Trace Analytics' }).click();
+    await page.getByRole('menuitemcheckbox', { name: 'HTTP status code' }).click();
 
-  await expect(panelEditPage.refreshPanel()).toBeOK();
-  await expect(panelEditPage.panel.getErrorIcon()).not.toBeVisible();
-  await expect(panelEditPage.panel.fieldNames).toHaveText(['Status Code', 'Count', 'Percent']);
-});
+    await expect(panelEditPage.refreshPanel()).toBeOK();
+    await expect(panelEditPage.panel.getErrorIcon()).not.toBeVisible();
+    await expect(panelEditPage.panel.fieldNames).toHaveText(['Status Code', 'Count', 'Percent']);
+  }
+);
 
-test('data query is successful when `Service Map` query is valid', async ({ page, panelEditPage, selectors }) => {
-  await panelEditPage.datasource.set('AWS X-Ray E2E');
-  await panelEditPage.setVisualization('Table');
+test(
+  'data query is successful when `Service Map` query is valid',
+  { tag: '@aws' },
+  async ({ page, panelEditPage, selectors }) => {
+    await panelEditPage.datasource.set(DATA_SOURCE_NAME);
+    await panelEditPage.setVisualization('Table');
 
-  await panelEditPage.getByGrafanaSelector(selectors.components.QueryField.container).click();
-  await page.keyboard.insertText('service("PetSite")');
-  await page.waitForTimeout(500); // Waits for query to update because <QueryField /> debounces onChange
-  await page.getByRole('button', { name: 'Trace List' }).click();
-  await page.getByRole('menuitemcheckbox', { name: 'Service Map' }).click();
+    await panelEditPage.getByGrafanaSelector(selectors.components.QueryField.container).click();
+    await page.keyboard.insertText('service("PetSite")');
+    await page.waitForTimeout(500); // Waits for query to update because <QueryField /> debounces onChange
+    await page.getByRole('button', { name: 'Trace List' }).click();
+    await page.getByRole('menuitemcheckbox', { name: 'Service Map' }).click();
 
-  await expect(panelEditPage.refreshPanel()).toBeOK();
-  await expect(panelEditPage.panel.getErrorIcon()).not.toBeVisible();
-  await expect(panelEditPage.panel.fieldNames).toHaveText([
-    /^(nodes )?id$/i,
-    'Name',
-    'Type',
-    'Average response time',
-    'Transactions per minute',
-    'Success',
-    'Fault',
-    'Error',
-    'Throttled',
-  ]);
-});
+    await expect(panelEditPage.refreshPanel()).toBeOK();
+    await expect(panelEditPage.panel.getErrorIcon()).not.toBeVisible();
+    await expect(panelEditPage.panel.fieldNames).toHaveText([
+      /^(nodes )?id$/i,
+      'Name',
+      'Type',
+      'Average response time',
+      'Transactions per minute',
+      'Success',
+      'Fault',
+      'Error',
+      'Throttled',
+    ]);
+  }
+);
 
-test('data query fails when query is invalid', async ({ page, panelEditPage, selectors }) => {
-  await panelEditPage.datasource.set('AWS X-Ray E2E');
+test('data query fails when query is invalid', { tag: '@aws' }, async ({ page, panelEditPage, selectors }) => {
+  await panelEditPage.datasource.set(DATA_SOURCE_NAME);
   await panelEditPage.setVisualization('Table');
 
   await panelEditPage.getByGrafanaSelector(selectors.components.QueryField.container).click();


### PR DESCRIPTION
- Add a positive AWS credential health check while preserving the existing Trace List, Trace Statistics, Trace Analytics, Service Map, and invalid-query coverage
- Run trusted CI and nightly Cloud coverage with DSI Vault selectors, optional PDC, Cloud-aware authentication, and a fork-safe smoke configuration
- Publish main builds to the internal dev catalog so DSE2EDEV can test the latest plugin; the first scheduled or manual Cloud run is available after this workflow merges
- Checks: Playwright smoke 2/2, Jest 61/61, Go tests, typecheck, lint, production build, spellcheck, Prettier, and Cloud/fork test discovery on Node 24.19.0

Closes: https://github.com/grafana/oss-plugin-partnerships/issues/1227
