### PR TITLE
Trace Statistics: scope by GroupName/ARN instead of injecting FilterExpression (#662)

### DIFF
--- a/pkg/datasource/datasource_test.go
+++ b/pkg/datasource/datasource_test.go
@@ -21,6 +21,7 @@ import (
 
 type XrayClientMock struct {
 	queryCalledWithRegion string
+	lastTimeSeriesInput   *xray.GetTimeSeriesServiceStatisticsInput
 }
 
 func (client *XrayClientMock) GetServiceGraph(_ context.Context, _ *xray.GetServiceGraphInput, _ ...func(*xray.Options)) (*xray.GetServiceGraphOutput, error) {
@@ -190,7 +191,8 @@ func (client *XrayClientMock) BatchGetTraces(_ context.Context, input *xray.Batc
 	}, nil
 }
 
-func (client *XrayClientMock) GetTimeSeriesServiceStatistics(_ context.Context, _ *xray.GetTimeSeriesServiceStatisticsInput, _ ...func(*xray.Options)) (*xray.GetTimeSeriesServiceStatisticsOutput, error) {
+func (client *XrayClientMock) GetTimeSeriesServiceStatistics(_ context.Context, input *xray.GetTimeSeriesServiceStatisticsInput, _ ...func(*xray.Options)) (*xray.GetTimeSeriesServiceStatisticsOutput, error) {
+	client.lastTimeSeriesInput = input
 	firstRow := 0
 	if client.queryCalledWithRegion != "" {
 		firstRow = 13
@@ -643,6 +645,42 @@ func TestDatasource(t *testing.T) {
 		require.Equal(t, int64(10), *response.Responses["A"].Frames[0].Fields[1].At(0).(*int64))
 		require.Equal(t, int64(11), *response.Responses["A"].Frames[0].Fields[1].At(2).(*int64))
 		require.Equal(t, 3.14/80, *response.Responses["A"].Frames[5].Fields[1].At(0).(*float64))
+	})
+
+	t.Run("getTimeSeriesServiceStatistics scopes by GroupName/ARN and does not use FilterExpression as query", func(t *testing.T) {
+		mock := &XrayClientMock{}
+		factory := func(_ context.Context, _ backend.PluginContext, requestSettings datasource.RequestSettings) (datasource.XrayClient, error) {
+			mock.queryCalledWithRegion = requestSettings.Region
+			return mock, nil
+		}
+		scopedDs := datasource.NewDatasource(context.Background(), factory, appSignalsClientFactory, settings)
+
+		groupFilter := `annotation.my_env = "staging"`
+		entityQuery := `service("api")`
+		groupARN := "arn:aws:xray:us-east-1:123456789012:group/staging/EXAMPLE"
+		response, err := queryDatasource(
+			scopedDs,
+			datasource.QueryGetTimeSeriesServiceStatistics,
+			datasource.GetTimeSeriesServiceStatisticsQueryData{
+				Query:   entityQuery,
+				Columns: []string{},
+				Group: &xraytypes.Group{
+					GroupName:        aws.String("staging"),
+					GroupARN:         aws.String(groupARN),
+					FilterExpression: aws.String(groupFilter),
+				},
+			},
+		)
+		require.NoError(t, err)
+		require.NoError(t, response.Responses["A"].Error)
+		require.NotNil(t, mock.lastTimeSeriesInput)
+		require.NotNil(t, mock.lastTimeSeriesInput.GroupName)
+		require.Equal(t, "staging", *mock.lastTimeSeriesInput.GroupName)
+		require.NotNil(t, mock.lastTimeSeriesInput.GroupARN)
+		require.Equal(t, groupARN, *mock.lastTimeSeriesInput.GroupARN)
+		require.NotNil(t, mock.lastTimeSeriesInput.EntitySelectorExpression)
+		require.Equal(t, entityQuery, *mock.lastTimeSeriesInput.EntitySelectorExpression)
+		require.NotEqual(t, groupFilter, *mock.lastTimeSeriesInput.EntitySelectorExpression)
 	})
 
 	t.Run("getTimeSeriesServiceStatistics query with region", func(t *testing.T) {

--- a/pkg/datasource/getTimeSeriesServiceStatistics.go
+++ b/pkg/datasource/getTimeSeriesServiceStatistics.go
@@ -17,10 +17,11 @@ import (
 )
 
 type GetTimeSeriesServiceStatisticsQueryData struct {
-	Query      string   `json:"query"`
-	Columns    []string `json:"columns"`
-	Resolution int32    `json:"resolution"`
-	Region     string   `json:"region"`
+	Query      string           `json:"query"`
+	Columns    []string         `json:"columns"`
+	Resolution int32            `json:"resolution"`
+	Region     string           `json:"region"`
+	Group      *xraytypes.Group `json:"group"`
 }
 
 type ValueDef struct {
@@ -130,6 +131,13 @@ func (ds *Datasource) getTimeSeriesServiceStatisticsForSingleQuery(ctx context.C
 		EndTime:                  &query.TimeRange.To,
 		EntitySelectorExpression: entitySelectorExpression,
 		Period:                   &resolution,
+	}
+
+	// Scope by group identity. Do not put Group.FilterExpression into EntitySelectorExpression —
+	// that field only accepts id()/service()/edge() selectors (see #662).
+	if queryData.Group != nil {
+		request.GroupName = queryData.Group.GroupName
+		request.GroupARN = queryData.Group.GroupARN
 	}
 	pager := xray.NewGetTimeSeriesServiceStatisticsPaginator(xrayClient, request)
 	var pagerError error

--- a/src/XRayDataSource.test.ts
+++ b/src/XRayDataSource.test.ts
@@ -165,12 +165,58 @@ describe('XrayDataSource', () => {
       expect(mockQuery.mock.calls[0][0].targets[0].query).toBe('service("test")');
     });
 
-    it('handles group', async () => {
+    it('does not inject group FilterExpression into Trace Statistics query', async () => {
       const ds = makeDatasourceWithResponse({} as any);
+      const group = {
+        FilterExpression: 'annotation.my_env = "staging"',
+        GroupName: 'staging',
+        GroupARN: 'arn:aws:xray:us-east-1:123456789012:group/staging/EXAMPLE',
+      };
       await firstValueFrom(
         ds.query(
           makeQuery({
             queryType: XrayQueryType.getTimeSeriesServiceStatistics,
+            query: 'service("something")',
+            group,
+          })
+        )
+      );
+      const mockQuery = (ds as any).mockQuery as jest.Mock;
+      const sent = mockQuery.mock.calls[0][0].targets[0];
+      expect(sent.query).toBe('service("something")');
+      expect(sent.group).toEqual(group);
+    });
+
+    it('does not use group FilterExpression as Trace Statistics query when query is empty', async () => {
+      const ds = makeDatasourceWithResponse({} as any);
+      const group = {
+        FilterExpression: 'annotation.my_env = "staging"',
+        GroupName: 'staging',
+        GroupARN: 'arn:aws:xray:us-east-1:123456789012:group/staging/EXAMPLE',
+      };
+      await firstValueFrom(
+        ds.query(
+          makeQuery({
+            queryType: XrayQueryType.getTimeSeriesServiceStatistics,
+            query: '',
+            group,
+          })
+        )
+      );
+      const mockQuery = (ds as any).mockQuery as jest.Mock;
+      const sent = mockQuery.mock.calls[0][0].targets[0];
+      expect(sent.query).toBe('');
+      expect(sent.group.GroupName).toBe('staging');
+      expect(sent.group.GroupARN).toBe(group.GroupARN);
+      expect(sent.query).not.toContain('annotation.my_env');
+    });
+
+    it('still injects group FilterExpression for Trace List', async () => {
+      const ds = makeDatasourceWithResponse({} as any);
+      await firstValueFrom(
+        ds.query(
+          makeQuery({
+            queryType: XrayQueryType.getTraceSummaries,
             query: 'service("something")',
             group: { FilterExpression: 'service("from group")' } as any,
           })

--- a/src/XRayDataSource.ts
+++ b/src/XRayDataSource.ts
@@ -384,7 +384,14 @@ function processRequest(request: DataQueryRequest<XrayQuery>, templateSrv: Templ
       // Add Group filter expression to the query filter expression. This seems to mimic what x-ray console is doing
       // as there are APIs that do not expect group just the filter expression. At the same time some APIs like Insights
       // do not accept filter expression just the groupARN so this will have to be adjusted for them.
-      if (target.group && target.group.FilterExpression && target.queryType !== XrayQueryType.getTrace) {
+      // GetTimeSeriesServiceStatistics scopes via GroupName/GroupARN; its EntitySelectorExpression only supports
+      // id()/service()/edge() — do not inject annotation-style group FilterExpressions into query (see #662).
+      if (
+        target.group &&
+        target.group.FilterExpression &&
+        target.queryType !== XrayQueryType.getTrace &&
+        target.queryType !== XrayQueryType.getTimeSeriesServiceStatistics
+      ) {
         if (newTarget.query) {
           newTarget.query = target.group.FilterExpression + ' AND ' + newTarget.query;
         } else {


### PR DESCRIPTION
## Summary

Fixes #662

For Trace Statistics, stop injecting the X-Ray Group's `FilterExpression` into `query` / `EntitySelectorExpression`. Pass `GroupName` and `GroupARN` to `GetTimeSeriesServiceStatistics` instead (annotation filters are invalid there).

Scoped to Trace Statistics only — other query types keep existing Group filter behavior.

## Test plan
- [x] Frontend: Trace Statistics with non-Default group does not AND FilterExpression into query; group still sent
- [x] Control: Trace List still injects FilterExpression
- [x] Backend: request includes GroupName/GroupARN; FilterExpression not used as EntitySelectorExpression
- [ ] Manual: panel with Group filter expression runs without InvalidRequestException

## CLA
Grafana CLA-assistant — will sign if prompted.