### PR TITLE
chore(security): bump fast-uri and immutable

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4879,13 +4879,6 @@
         "immutable": "^3.8.2"
       }
     },
-    "node_modules/@types/slate/node_modules/immutable": {
-      "version": "4.3.9",
-      "resolved": "https://registry.npmjs.org/immutable/-/immutable-4.3.9.tgz",
-      "integrity": "sha512-ObHy4YN7ycwZOUCLI1/6svfyAFu7vL8RhAvVu/bh/RZW9EPlOyDaQ9jDQWCtdqzaXUjgXZCW1migtHE7YI7UGQ==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/@types/stack-utils": {
       "version": "2.0.3",
       "dev": true,

--- a/package-lock.json
+++ b/package-lock.json
@@ -4880,12 +4880,11 @@
       }
     },
     "node_modules/@types/slate/node_modules/immutable": {
-      "version": "3.8.4",
+      "version": "4.3.9",
+      "resolved": "https://registry.npmjs.org/immutable/-/immutable-4.3.9.tgz",
+      "integrity": "sha512-ObHy4YN7ycwZOUCLI1/6svfyAFu7vL8RhAvVu/bh/RZW9EPlOyDaQ9jDQWCtdqzaXUjgXZCW1migtHE7YI7UGQ==",
       "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
+      "license": "MIT"
     },
     "node_modules/@types/stack-utils": {
       "version": "2.0.3",
@@ -8360,7 +8359,9 @@
       "version": "1.0.0"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.5",
+      "version": "3.1.6",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.6.tgz",
+      "integrity": "sha512-7Ical1vFEMr0onbVzEDIreM22I4khW+fzyQPwvAFWBp1iwdshSZRsL4jjRvPG9JP1uiqMHRto+YU6R2/CzDz5Q==",
       "dev": true,
       "funding": [
         {

--- a/package.json
+++ b/package.json
@@ -101,5 +101,11 @@
   "engines": {
     "node": ">=24",
     "npm": ">=11.16.0"
+  },
+  "overrides": {
+    "fast-uri": "3.1.6",
+    "@types/slate": {
+      "immutable": "4.3.9"
+    }
   }
 }

--- a/package.json
+++ b/package.json
@@ -103,9 +103,8 @@
     "npm": ">=11.16.0"
   },
   "overrides": {
-    "fast-uri": "3.1.6",
     "@types/slate": {
-      "immutable": "4.3.9"
+      "immutable": "5.1.9"
     }
   }
 }


### PR DESCRIPTION
## Summary
- Remaining JS CVEs from [grafana/data-sources#1825](https://github.com/grafana/data-sources/issues/1825) after backend bumps in #695.
- `fast-uri` **3.1.6** via lockfile refresh (`ajv@8.20.0` already allows `^3.0.1`); no override.
- `@types/slate` nested `immutable` forced to **5.1.9**, matching grafana/grafana's `@types/slate/immutable` resolution and this plugin's existing Grafana `immutable@5.1.9` (hoists; no extra 3.x/4.x copy).

| Package | From | To | Severities | CVEs | Strategy |
|---|---|---|---|---|---|
| `fast-uri` | 3.1.5 | 3.1.6 | HIGH | CVE-2026-76172, CVE-2026-75975, CVE-2026-75931, CVE-2026-75899 | natural re-resolution |
| `immutable` (`@types/slate`) | 3.8.4 | 5.1.9 | HIGH | CVE-2026-59879 | nested override (Grafana core pattern) |

## Test plan
- [x] `npm run test:ci`, `typecheck`, `lint` (pre-existing warnings only)
- [x] `npm run build` + `mage build:linux`
- [x] Local Grafana 12.2.0 after the 5.1.9 / no-`fast-uri`-override change:
  - plugin registered as AWS Application Signals 2.17.1
  - config editor renders (auth, region, assume role)
  - Test hits backend `GetGroups` (fails only because provisioned AWS keys are empty)
  - Explore query editor renders (Region, Traces, Trace List, Slate query field); typing into the query field produced no console errors
- [x] CI green